### PR TITLE
chore: bump version to 16.0.1

### DIFF
--- a/packages/cache-handler/package.json
+++ b/packages/cache-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrjasonroy/cache-components-cache-handler",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "description": "Cache handler for Next.js 16+ with support for 'use cache' directive and Cache Components",
   "author": "Jason Roy",
   "license": "MIT",
@@ -14,7 +14,9 @@
       "default": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/packages/cache-handler/package.json
+++ b/packages/cache-handler/package.json
@@ -14,9 +14,7 @@
       "default": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Version Bump to 16.0.1

This PR bumps the package version as requested.

### Changes
- Updated package.json version to 16.0.1
- Updated pnpm-lock.yaml

### Next Steps
1. Review and merge this PR
2. After merge, the tag `v16.0.1` will be created automatically
3. Create a GitHub release from the tag
4. Publishing to npm will happen automatically

**npm dist-tag:** `latest`
