### PR TITLE
chore: bump version to 16.0.4

### DIFF
--- a/packages/cache-handler/package.json
+++ b/packages/cache-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrjasonroy/cache-components-cache-handler",
-  "version": "16.0.3",
+  "version": "16.0.4",
   "description": "Cache handler for Next.js 16+ with support for 'use cache' directive and Cache Components",
   "author": "Jason Roy",
   "license": "MIT",


### PR DESCRIPTION
## Version Bump to 16.0.4

This PR bumps the package version as requested.

### Changes
- Updated package.json version to 16.0.4
- Updated pnpm-lock.yaml

### Next Steps
1. Review and merge this PR
2. After merge, the tag `v16.0.4` will be created automatically
3. Create a GitHub release from the tag
4. Publishing to npm will happen automatically

**npm dist-tag:** `latest`
