### PR TITLE
Fix workflow path error for packages/cache-handler-redis

### DIFF
--- a/.github/workflows/nextjs-version-check.yml
+++ b/.github/workflows/nextjs-version-check.yml
@@ -87,11 +87,6 @@ jobs:
           npm version $NEW_PKG_VERSION --no-git-tag-version --allow-same-version
           cd ../..
 
-          # Update Redis package
-          cd packages/cache-handler-redis
-          npm version $NEW_PKG_VERSION --no-git-tag-version --allow-same-version
-          cd ../..
-
       - name: Install updated dependencies
         if: steps.check_version.outputs.needs_update == 'true'
         run: pnpm install


### PR DESCRIPTION
## Summary

- Removed reference to non-existent `packages/cache-handler-redis` directory in the `nextjs-version-check.yml` workflow
- This fixes the error: `cd: packages/cache-handler-redis: No such file or directory`

## Root Cause

The workflow was copied from a repo that has both `packages/cache-handler` and `packages/cache-handler-redis`, but this fork only has `packages/cache-handler`.

## Test plan

- [x] Re-run the `Next.js Version Check` workflow manually to verify it completes successfully

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)