### PR TITLE
fix: resolve 3 workflow automation bugs causing daily CI failures

### DIFF
--- a/.github/workflows/catch-up-release.yml
+++ b/.github/workflows/catch-up-release.yml
@@ -19,6 +19,17 @@ jobs:
       contents: write
       pull-requests: write
 
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -102,13 +113,6 @@ jobs:
         if: steps.versions.outputs.needs_update == 'true'
         run: pnpm build
 
-      - name: Start Docker services
-        if: steps.versions.outputs.needs_update == 'true'
-        run: |
-          docker compose up -d
-          sleep 5
-          docker ps
-
       - name: Install Playwright browsers
         if: steps.versions.outputs.needs_update == 'true'
         run: |
@@ -127,17 +131,13 @@ jobs:
         if: steps.versions.outputs.needs_update == 'true'
         id: test_redis
         run: |
-          # Flush Redis
-          docker exec nextjs-cache-redis redis-cli FLUSHALL
+          # Flush Redis (service container is accessible on localhost)
+          redis-cli -h localhost FLUSHALL
 
           # Build and test with Redis
           cd apps/e2e-test-app
           CACHE_HANDLER=redis pnpm build
           CACHE_HANDLER=redis pnpm test:e2e
-
-      - name: Stop Docker services
-        if: always()
-        run: docker compose down || true
 
       - name: Create branch and commit
         if: steps.versions.outputs.needs_update == 'true' && inputs.dry_run != true

--- a/.github/workflows/nextjs-version-check.yml
+++ b/.github/workflows/nextjs-version-check.yml
@@ -13,6 +13,17 @@ jobs:
       contents: write
       pull-requests: write
 
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     outputs:
       needs_update: ${{ steps.check_version.outputs.needs_update }}
       latest_version: ${{ steps.check_version.outputs.latest_version }}
@@ -38,7 +49,8 @@ jobs:
         id: check_version
         run: |
           # Get current Next.js version from e2e-test-app (what we're testing against)
-          CURRENT_NEXTJS=$(node -p "require('./apps/e2e-test-app/package.json').dependencies.next")
+          # Strip semver range prefix (^, ~, >=, etc.) to get bare version for comparison
+          CURRENT_NEXTJS=$(node -p "require('./apps/e2e-test-app/package.json').dependencies.next.replace(/^[^0-9]*/, '')")
           echo "Current Next.js in e2e-test-app: $CURRENT_NEXTJS"
 
           # Get current package version
@@ -139,13 +151,6 @@ jobs:
         if: steps.check_version.outputs.needs_update == 'true' && steps.branch_check.outputs.branch_exists != 'true'
         run: pnpm build
 
-      - name: Start Docker services
-        if: steps.check_version.outputs.needs_update == 'true' && steps.branch_check.outputs.branch_exists != 'true'
-        run: |
-          docker compose up -d
-          sleep 5
-          docker ps
-
       - name: Install Playwright browsers
         if: steps.check_version.outputs.needs_update == 'true' && steps.branch_check.outputs.branch_exists != 'true'
         run: |
@@ -164,8 +169,8 @@ jobs:
       - name: Run e2e tests with Redis
         if: steps.check_version.outputs.needs_update == 'true' && steps.branch_check.outputs.branch_exists != 'true'
         run: |
-          # Flush Redis
-          docker exec nextjs-cache-redis redis-cli FLUSHALL
+          # Flush Redis (service container is accessible on localhost)
+          redis-cli -h localhost FLUSHALL
 
           # Build and test with Redis
           cd apps/e2e-test-app
@@ -173,10 +178,6 @@ jobs:
           CACHE_HANDLER=redis pnpm test:e2e
         continue-on-error: true
         id: test_redis
-
-      - name: Stop Docker services
-        if: always()
-        run: docker compose down || true
 
       - name: Commit changes
         if: steps.check_version.outputs.needs_update == 'true' && steps.branch_check.outputs.branch_exists != 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish to npm
 
 on:
-  release:
-    types: [published]
   push:
     tags:
       - "v*.*.*"


### PR DESCRIPTION
## What broke and why

### Bug 1: Semver caret prefix caused false 'update needed' every day
`require().dependencies.next` returns `^16.1.6` but `npm view next version` returns `16.1.6`. String comparison always evaluated to `true`, creating a new branch and running tests daily even when already on the latest version.

**Fix:** Strip non-numeric prefix before comparing (`.replace(/^[^0-9]*/, '')`).

### Bug 2: Docker Compose Redis setup failed in version-check workflow
The workflow used `docker compose up -d && sleep 5` which is fragile — Redis wasn't ready in time, causing blank `[Redis] Error:` connection failures. Also hardcoded `docker exec nextjs-cache-redis` which doesn't exist in the CI environment.

**Fix:** Replaced with GitHub Actions service containers (same pattern as `ci.yml`), with proper health checks. Updated Redis flush to use `redis-cli -h localhost FLUSHALL`.

Same fix applied to `catch-up-release.yml`.

### Bug 3: Double-publish in publish.yml
`publish.yml` triggered on both `push: tags` and `release: published`. The tag-push run creates a GitHub release at the end (`gh release create`), which re-triggers the workflow — second run fails with npm error 'version already published'.

**Fix:** Removed `release: published` trigger. Tag push alone is sufficient.

---

*Analysis and fix by Iris + Claude Code*