### PR TITLE
fixed ttl inconsistency between usage of ioredis and node-redis clients

### DIFF
--- a/apps/e2e-test-app/data-cache-handler.mjs
+++ b/apps/e2e-test-app/data-cache-handler.mjs
@@ -12,7 +12,7 @@ let handler;
 if (cacheType === "redis") {
   // Redis/Valkey handler (using ioredis for consistency)
   const Redis = (await import("ioredis")).default;
-  const { createRedisDataCacheHandler } = await import(
+  const { createRedisDataCacheHandler, createIoredisAdapter } = await import(
     "@mrjasonroy/cache-components-cache-handler"
   );
 
@@ -27,17 +27,9 @@ if (cacheType === "redis") {
     console.log("[Redis] Connected successfully to", url);
   });
 
-  // Wrap ioredis to provide node-redis compatible API
-  const redis = {
-    get: (key) => ioredisClient.get(key),
-    set: (key, value, ...args) => ioredisClient.set(key, value, ...args),
-    del: (...keys) => ioredisClient.del(...keys),
-    exists: (...keys) => ioredisClient.exists(...keys),
-    ttl: (key) => ioredisClient.ttl(key),
-    hGet: (key, field) => ioredisClient.hget(key, field),
-    hSet: (key, field, value) => ioredisClient.hset(key, field, value),
-    hGetAll: (key) => ioredisClient.hgetall(key),
-  };
+  // Adapt the ioredis client to the node-redis-style RedisClient contract
+  // (translates SET { EX } options to ioredis positional args)
+  const redis = createIoredisAdapter(ioredisClient);
 
   handler = createRedisDataCacheHandler({
     redis,
@@ -49,7 +41,7 @@ if (cacheType === "redis") {
 } else if (cacheType === "elasticache") {
   // ElastiCache handler (password-based auth only)
   const Redis = (await import("ioredis")).default;
-  const { createRedisDataCacheHandler } = await import(
+  const { createRedisDataCacheHandler, createIoredisAdapter } = await import(
     "@mrjasonroy/cache-components-cache-handler"
   );
 
@@ -93,17 +85,9 @@ if (cacheType === "redis") {
     console.log("[ElastiCache] Connected successfully to", endpoint);
   });
 
-  // Wrap ioredis to provide node-redis compatible API
-  const redis = {
-    get: (key) => ioredisClient.get(key),
-    set: (key, value, ...args) => ioredisClient.set(key, value, ...args),
-    del: (...keys) => ioredisClient.del(...keys),
-    exists: (...keys) => ioredisClient.exists(...keys),
-    ttl: (key) => ioredisClient.ttl(key),
-    hGet: (key, field) => ioredisClient.hget(key, field),
-    hSet: (key, field, value) => ioredisClient.hset(key, field, value),
-    hGetAll: (key) => ioredisClient.hgetall(key),
-  };
+  // Adapt the ioredis client to the node-redis-style RedisClient contract
+  // (translates SET { EX } options to ioredis positional args)
+  const redis = createIoredisAdapter(ioredisClient);
 
   handler = createRedisDataCacheHandler({
     redis,

--- a/packages/cache-handler/src/data-cache/factory.ts
+++ b/packages/cache-handler/src/data-cache/factory.ts
@@ -4,8 +4,9 @@
  */
 
 import { createRequire } from "node:module";
+import { createIoredisAdapter } from "./ioredis-adapter.js";
 import { createMemoryDataCacheHandler } from "./memory.js";
-import { type RedisClient, createRedisDataCacheHandler } from "./redis.js";
+import { createRedisDataCacheHandler } from "./redis.js";
 import type { DataCacheHandler } from "./types.js";
 
 const nodeRequire = createRequire(import.meta.url);
@@ -21,30 +22,6 @@ function loadIoredis(type: string): typeof import("ioredis").default {
       `ioredis is required for ${type} cache handler. Install it with: npm install ioredis`,
     );
   }
-}
-
-/**
- * Create adapter for ioredis (lowercase methods) to match RedisClient interface (camelCase).
- * Translates node-redis-style SET options `{ EX: seconds }` to ioredis positional args.
- */
-function createRedisAdapter(redis: import("ioredis").default): RedisClient {
-  return {
-    get: (key) => redis.get(key),
-    set: (key, value, ...args) => {
-      // node-redis style: set(key, value, { EX: seconds })
-      const opts = args[0] as Record<string, unknown> | undefined;
-      if (opts && typeof opts === "object" && typeof opts.EX === "number") {
-        return redis.set(key, value, "EX", opts.EX) as Promise<unknown>;
-      }
-      return redis.set(key, value) as Promise<unknown>;
-    },
-    del: (...keys) => redis.del(...keys),
-    exists: (...keys) => redis.exists(...keys),
-    ttl: (key) => redis.ttl(key),
-    hGet: (key, field) => redis.hget(key, field),
-    hSet: (key, field, value) => redis.hset(key, field, value) as Promise<unknown>,
-    hGetAll: (key) => redis.hgetall(key),
-  };
 }
 
 export type CacheHandlerType = "memory" | "redis" | "valkey" | "elasticache";
@@ -153,7 +130,7 @@ export function createCacheHandler(options: CacheHandlerOptions): DataCacheHandl
               ...(tlsEnabled ? { tls: {} } : {}),
             })
           : new Redis(url);
-      const redisAdapter = createRedisAdapter(redis);
+      const redisAdapter = createIoredisAdapter(redis);
 
       return createRedisDataCacheHandler({
         redis: redisAdapter,
@@ -194,7 +171,7 @@ export function createCacheHandler(options: CacheHandlerOptions): DataCacheHandl
         },
       });
 
-      const redisAdapter = createRedisAdapter(redis);
+      const redisAdapter = createIoredisAdapter(redis);
 
       return createRedisDataCacheHandler({
         redis: redisAdapter,

--- a/packages/cache-handler/src/data-cache/factory.ts
+++ b/packages/cache-handler/src/data-cache/factory.ts
@@ -24,14 +24,17 @@ function loadIoredis(type: string): typeof import("ioredis").default {
 }
 
 /**
- * Create adapter for ioredis (lowercase methods) to match RedisClient interface (camelCase)
+ * Create adapter for ioredis (lowercase methods) to match RedisClient interface (camelCase).
+ * Translates node-redis-style SET options `{ EX: seconds }` to ioredis positional args.
  */
 function createRedisAdapter(redis: import("ioredis").default): RedisClient {
   return {
     get: (key) => redis.get(key),
-    set: (key, value, exFlag?, ttl?) => {
-      if (exFlag === "EX" && typeof ttl === "number") {
-        return redis.set(key, value, "EX", ttl) as Promise<unknown>;
+    set: (key, value, ...args) => {
+      // node-redis style: set(key, value, { EX: seconds })
+      const opts = args[0] as Record<string, unknown> | undefined;
+      if (opts && typeof opts === "object" && typeof opts.EX === "number") {
+        return redis.set(key, value, "EX", opts.EX) as Promise<unknown>;
       }
       return redis.set(key, value) as Promise<unknown>;
     },

--- a/packages/cache-handler/src/data-cache/ioredis-adapter.test.ts
+++ b/packages/cache-handler/src/data-cache/ioredis-adapter.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import { createIoredisAdapter } from "./ioredis-adapter.js";
+
+/**
+ * Captures the exact arguments forwarded to the underlying ioredis client so
+ * we can assert the node-redis -> ioredis translation, especially for SET TTLs.
+ */
+function createFakeIoredis() {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const record =
+    (method: string, result: unknown) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+      return Promise.resolve(result);
+    };
+  return {
+    calls,
+    client: {
+      get: record("get", "value"),
+      set: record("set", "OK"),
+      del: record("del", 1),
+      exists: record("exists", 1),
+      ttl: record("ttl", 42),
+      hget: record("hget", "field-value"),
+      hset: record("hset", 1),
+      hgetall: record("hgetall", { a: "1" }),
+    },
+  };
+}
+
+describe("createIoredisAdapter", () => {
+  test("translates node-redis SET options { EX } to ioredis positional args", async () => {
+    const { client, calls } = createFakeIoredis();
+    const adapter = createIoredisAdapter(client);
+
+    await adapter.set("key", "value", { EX: 60 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ method: "set", args: ["key", "value", "EX", 60] });
+  });
+
+  test("issues a plain SET when no TTL options are provided", async () => {
+    const { client, calls } = createFakeIoredis();
+    const adapter = createIoredisAdapter(client);
+
+    await adapter.set("key", "value");
+
+    expect(calls[0]).toEqual({ method: "set", args: ["key", "value"] });
+  });
+
+  test("does not pass through unrecognized option objects to ioredis", async () => {
+    const { client, calls } = createFakeIoredis();
+    const adapter = createIoredisAdapter(client);
+
+    // An object without a numeric EX must not be forwarded verbatim (that is
+    // exactly what triggers ioredis "ERR syntax error").
+    await adapter.set("key", "value", { NX: true } as unknown as { EX: number });
+
+    expect(calls[0]).toEqual({ method: "set", args: ["key", "value"] });
+  });
+
+  test("maps camelCase hash methods to ioredis lowercase methods", async () => {
+    const { client, calls } = createFakeIoredis();
+    const adapter = createIoredisAdapter(client);
+
+    await adapter.hGet("h", "f");
+    await adapter.hSet("h", "f", "v");
+    await adapter.hGetAll("h");
+
+    expect(calls.map((c) => c.method)).toEqual(["hget", "hset", "hgetall"]);
+    expect(calls[1].args).toEqual(["h", "f", "v"]);
+  });
+
+  test("delegates get/del/exists/ttl to the underlying client", async () => {
+    const { client, calls } = createFakeIoredis();
+    const adapter = createIoredisAdapter(client);
+
+    expect(await adapter.get("k")).toBe("value");
+    expect(await adapter.ttl("k")).toBe(42);
+    await adapter.del("k1", "k2");
+    await adapter.exists("k1", "k2");
+
+    expect(calls.find((c) => c.method === "del")?.args).toEqual(["k1", "k2"]);
+    expect(calls.find((c) => c.method === "exists")?.args).toEqual(["k1", "k2"]);
+  });
+});

--- a/packages/cache-handler/src/data-cache/ioredis-adapter.ts
+++ b/packages/cache-handler/src/data-cache/ioredis-adapter.ts
@@ -1,0 +1,65 @@
+import type { RedisClient } from "./redis.js";
+
+/**
+ * Minimal structural type for an ioredis-compatible client.
+ *
+ * Only the methods the data cache handler relies on are declared, so consumers
+ * don't need ioredis' types in scope to call {@link createIoredisAdapter}. Both
+ * ioredis `Redis` and `Cluster` instances satisfy this shape.
+ */
+export interface IoredisLike {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ...args: unknown[]): Promise<unknown>;
+  del(...keys: string[]): Promise<number>;
+  exists(...keys: string[]): Promise<number>;
+  ttl(key: string): Promise<number>;
+  hget(key: string, field: string): Promise<string | null>;
+  hset(key: string, field: string, value: string): Promise<unknown>;
+  hgetall(key: string): Promise<Record<string, string>>;
+}
+
+/**
+ * Wrap an ioredis client so it satisfies the node-redis-style {@link RedisClient}
+ * contract expected by `createRedisDataCacheHandler`.
+ *
+ * The data cache handler issues node-redis-style SET options
+ * (`set(key, value, { EX: seconds })`). ioredis instead expects positional
+ * arguments (`set(key, value, "EX", seconds)`), so this adapter translates the
+ * option object. Passing a raw ioredis client without this translation makes
+ * Redis reject the SET with `ERR syntax error`, silently breaking TTLs and
+ * caching.
+ *
+ * @example
+ * ```typescript
+ * import Redis from "ioredis";
+ * import {
+ *   createIoredisAdapter,
+ *   createRedisDataCacheHandler,
+ * } from "@mrjasonroy/cache-components-cache-handler";
+ *
+ * const client = new Redis(process.env.REDIS_URL);
+ *
+ * export default createRedisDataCacheHandler({
+ *   redis: createIoredisAdapter(client),
+ * });
+ * ```
+ */
+export function createIoredisAdapter(redis: IoredisLike): RedisClient {
+  return {
+    get: (key) => redis.get(key),
+    set: (key, value, ...args) => {
+      // node-redis style: set(key, value, { EX: seconds }) -> ioredis "EX", seconds
+      const opts = args[0] as { EX?: number } | undefined;
+      if (opts && typeof opts === "object" && typeof opts.EX === "number") {
+        return redis.set(key, value, "EX", opts.EX);
+      }
+      return redis.set(key, value);
+    },
+    del: (...keys) => redis.del(...keys),
+    exists: (...keys) => redis.exists(...keys),
+    ttl: (key) => redis.ttl(key),
+    hGet: (key, field) => redis.hget(key, field),
+    hSet: (key, field, value) => redis.hset(key, field, value),
+    hGetAll: (key) => redis.hgetall(key),
+  };
+}

--- a/packages/cache-handler/src/data-cache/redis.test.ts
+++ b/packages/cache-handler/src/data-cache/redis.test.ts
@@ -27,9 +27,10 @@ class FakeRedis {
     this.setCalls.push({ key, args });
 
     let expireAt: number | undefined;
-    // ioredis style: set(key, value, "EX", seconds)
-    if (args[0] === "EX" && typeof args[1] === "number") {
-      expireAt = Date.now() + args[1] * 1000;
+    // node-redis style: set(key, value, { EX: seconds })
+    const opts = args[0] as { EX?: number } | undefined;
+    if (opts && typeof opts === "object" && typeof opts.EX === "number") {
+      expireAt = Date.now() + opts.EX * 1000;
     }
 
     this.store.set(key, { value, expireAt });
@@ -147,7 +148,7 @@ describe("RedisDataCacheHandler", () => {
     expect(redis.setCalls).toHaveLength(1);
     expect(redis.setCalls[0]).toMatchObject({
       key: "nextjs:data-cache:cache-key",
-      args: ["EX", 120],
+      args: [{ EX: 120 }],
     });
 
     const result = await handler.get("cache-key", []);
@@ -231,7 +232,7 @@ describe("RedisDataCacheHandler", () => {
     expect(redis.delCalls).toContainEqual(["nextjs:data-cache:invalidate-key"]);
   });
 
-  test("sets TTL correctly with ioredis style args (fixes #16)", async () => {
+  test("sets TTL correctly with node-redis style options (fixes #16)", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(BASE_TIME);
 
@@ -241,11 +242,11 @@ describe("RedisDataCacheHandler", () => {
     const entry = createEntry("ttl-test", { expire: 60, revalidate: 30 });
     await handler.set("ttl-key", Promise.resolve(entry));
 
-    // Verify the set call used ioredis style: "EX", seconds
+    // Verify the set call used node-redis style: { EX: seconds }
     expect(redis.setCalls).toHaveLength(1);
     const setCall = redis.setCalls[0];
     expect(setCall.key).toBe("nextjs:data-cache:ttl-key");
-    expect(setCall.args).toEqual(["EX", 60]);
+    expect(setCall.args).toEqual([{ EX: 60 }]);
   });
 
   test("TTL causes entry to expire after specified time", async () => {
@@ -286,6 +287,6 @@ describe("RedisDataCacheHandler", () => {
     await handler.set("default-ttl-key", Promise.resolve(entry));
 
     expect(redis.setCalls).toHaveLength(1);
-    expect(redis.setCalls[0].args).toEqual(["EX", 3600]);
+    expect(redis.setCalls[0].args).toEqual([{ EX: 3600 }]);
   });
 });

--- a/packages/cache-handler/src/data-cache/redis.ts
+++ b/packages/cache-handler/src/data-cache/redis.ts
@@ -41,7 +41,8 @@ export interface RedisDataCacheHandlerOptions {
 }
 
 /**
- * Redis client interface (node-redis)
+ * Redis client interface (node-redis compatible)
+ * Uses node-redis-style SET with options object: set(key, value, { EX: seconds })
  */
 export interface RedisClient {
   get(key: string): Promise<string | null>;

--- a/packages/cache-handler/src/data-cache/redis.ts
+++ b/packages/cache-handler/src/data-cache/redis.ts
@@ -10,7 +10,7 @@ import type { DataCacheEntry, DataCacheHandler } from "./types.js";
 
 export interface RedisDataCacheHandlerOptions {
   /**
-   * Redis client instance (ioredis compatible)
+   * Redis client instance (node-redis)
    */
   redis: RedisClient;
 
@@ -41,8 +41,7 @@ export interface RedisDataCacheHandlerOptions {
 }
 
 /**
- * Redis client interface (ioredis compatible)
- * Uses ioredis-style SET with "EX" positional args: set(key, value, "EX", seconds)
+ * Redis client interface (node-redis)
  */
 export interface RedisClient {
   get(key: string): Promise<string | null>;
@@ -275,7 +274,7 @@ export function createRedisDataCacheHandler(
         const ttl = entry.expire < 4294967294 ? entry.expire : defaultTTL;
 
         // Store in Redis with TTL
-        await redis.set(key, JSON.stringify(serialized), "EX", Math.ceil(ttl));
+        await redis.set(key, JSON.stringify(serialized), { EX: Math.ceil(ttl) });
 
         log?.("set", cacheKey, "done", { ttl });
       } catch (error) {

--- a/packages/cache-handler/src/index.ts
+++ b/packages/cache-handler/src/index.ts
@@ -65,6 +65,11 @@ export {
   type RedisClient,
   type RedisDataCacheHandlerOptions,
 } from "./data-cache/redis.js";
+// Adapter for using an ioredis client with the node-redis-style data cache handler
+export {
+  createIoredisAdapter,
+  type IoredisLike,
+} from "./data-cache/ioredis-adapter.js";
 export type {
   DataCacheEntry,
   DataCacheHandler,


### PR DESCRIPTION
## Description

The data cache Redis implementation is designed to use a node-redis instance (as indicated by the examples and Redis interface). However, the TTL is currently being set using ioredis syntax, which is incompatible with node-redis. As a result, the TTL on redis entry is not being set at all.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chore (dependencies, CI, etc.)

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass (`pnpm test`)
- [ ] Added new tests for new functionality
- [ ] Tested with memory cache handler
- [x] Tested with Redis cache handler (if applicable)
- [ ] E2E tests pass (`pnpm test:e2e`)

## Checklist

- [x] My code follows the project's code style (`pnpm lint` passes)
- [x] I have run `pnpm format` to format my code
- [x] Type checking passes (`pnpm typecheck`)
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues

<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->

## Additional Context

<!-- Add any other context about the PR here -->
