### PR TITLE
test: de-flake tag revalidation e2e (isolation + condition waits)

### DIFF
--- a/apps/e2e-test-app/app/revalidate-test/actions.ts
+++ b/apps/e2e-test-app/app/revalidate-test/actions.ts
@@ -2,12 +2,14 @@
 
 import { revalidateTag, updateTag } from "next/cache";
 
-export async function revalidateTestTag() {
-  revalidateTag("test-tag", "max");
-  return { revalidated: true, type: "revalidateTag" };
+const DEFAULT_TAG = "test-tag";
+
+export async function revalidateTestTag(tag: string = DEFAULT_TAG) {
+  revalidateTag(tag, "max");
+  return { revalidated: true, type: "revalidateTag", tag };
 }
 
-export async function updateTestTag() {
-  updateTag("test-tag");
-  return { updated: true, type: "updateTag" };
+export async function updateTestTag(tag: string = DEFAULT_TAG) {
+  updateTag(tag);
+  return { updated: true, type: "updateTag", tag };
 }

--- a/apps/e2e-test-app/app/revalidate-test/page.tsx
+++ b/apps/e2e-test-app/app/revalidate-test/page.tsx
@@ -1,23 +1,45 @@
 import { getTaggedData } from "@/lib/tagged-data";
+import { Suspense } from "react";
 import { RevalidateForms } from "./revalidate-form";
 
 // E2E-201-202: Tag-based revalidation
+// Accepts an optional `?tag=` so each test can use an isolated tag and avoid
+// cross-test interference (revalidating one test's tag must not affect another).
+// Reading searchParams is dynamic, so it lives inside a Suspense boundary as
+// required by cacheComponents.
 
-export default async function Page() {
-  const data = await getTaggedData("test-tag");
-
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ tag?: string }>;
+}) {
   return (
     <div>
       <h1>E2E-201-202: Revalidation Test</h1>
+      <Suspense fallback={<p>Loading…</p>}>
+        <RevalidateContent searchParams={searchParams} />
+      </Suspense>
+      <a href="/">Back to home</a>
+    </div>
+  );
+}
+
+async function RevalidateContent({
+  searchParams,
+}: {
+  searchParams: Promise<{ tag?: string }>;
+}) {
+  const { tag = "test-tag" } = await searchParams;
+  const data = await getTaggedData(tag);
+
+  return (
+    <>
       <div data-testid="tagged-content">
         <p>Tag: {data.tag}</p>
         <p>Timestamp: {data.timestamp}</p>
         <p>Random: {data.randomValue}</p>
       </div>
-
-      <RevalidateForms />
-
-      <a href="/">Back to home</a>
-    </div>
+      <RevalidateForms tag={tag} />
+    </>
   );
 }

--- a/apps/e2e-test-app/app/revalidate-test/revalidate-form.tsx
+++ b/apps/e2e-test-app/app/revalidate-test/revalidate-form.tsx
@@ -2,13 +2,13 @@
 
 import { revalidateTestTag, updateTestTag } from "./actions";
 
-export function RevalidateForms() {
+export function RevalidateForms({ tag }: { tag?: string }) {
   return (
     <div>
       <h3>Test Actions:</h3>
       <form
         action={async () => {
-          await revalidateTestTag();
+          await revalidateTestTag(tag);
           window.location.reload();
         }}
       >
@@ -19,7 +19,7 @@ export function RevalidateForms() {
 
       <form
         action={async () => {
-          await updateTestTag();
+          await updateTestTag(tag);
           window.location.reload();
         }}
       >

--- a/apps/e2e-test-app/tests/e2e/revalidation.spec.ts
+++ b/apps/e2e-test-app/tests/e2e/revalidation.spec.ts
@@ -1,50 +1,66 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
+
+const CONTENT = '[data-testid="tagged-content"]';
+
+/**
+ * Returns the cached content once caching has demonstrably stabilized.
+ *
+ * The cached component embeds a timestamp + Math.random(), so it only stays
+ * identical across reloads when it is actually served from cache. The first
+ * render is a cold miss whose `"use cache"` write commits asynchronously with
+ * no client-observable signal, so we let the write settle, then reload and
+ * compare. `toPass` retries the whole cycle until two consecutive loads match,
+ * which removes the race that made a single fixed-timeout reload flaky.
+ */
+async function waitForCachedContent(page: Page): Promise<string> {
+  let cached = "";
+  await expect(async () => {
+    const before = await page.locator(CONTENT).textContent();
+    // Give the asynchronous cache write from this render time to commit before
+    // reloading; otherwise the next load is another cold miss.
+    await page.waitForTimeout(500);
+    await page.reload();
+    const after = await page.locator(CONTENT).textContent();
+    expect(after).toBe(before);
+    cached = after ?? "";
+  }).toPass({ timeout: 20_000, intervals: [500, 1000] });
+  return cached;
+}
+
+/**
+ * Reloads until the content differs from `previous`, proving the invalidation
+ * took effect. Avoids a fixed wait that may be too short (test flakes) or
+ * needlessly long.
+ */
+async function waitForChangedContent(page: Page, previous: string): Promise<void> {
+  await expect(async () => {
+    await page.reload();
+    const current = await page.locator(CONTENT).textContent();
+    expect(current).not.toBe(previous);
+  }).toPass({ timeout: 20_000, intervals: [500, 1000] });
+}
 
 test.describe("Tag-Based Revalidation (E2E-201-202)", () => {
+  // Each test uses its own tag so invalidating one cannot affect the other.
   test("E2E-201: revalidateTag invalidates cached component", async ({ page }) => {
-    // First visit - get initial timestamp
-    await page.goto("/revalidate-test");
-    const firstContent = await page.locator('[data-testid="tagged-content"]').textContent();
+    await page.goto("/revalidate-test?tag=e2e-201-revalidate");
 
-    // Wait a bit
-    await page.waitForTimeout(200);
+    // Establish a confirmed-cached baseline (stable across reloads).
+    const cachedContent = await waitForCachedContent(page);
 
-    // Refresh - should still be cached
-    await page.reload();
-    const cachedContent = await page.locator('[data-testid="tagged-content"]').textContent();
-    expect(cachedContent).toBe(firstContent);
-
-    // Click revalidate button
+    // Invalidate by tag, then confirm the content changes.
     await page.click('[data-testid="revalidate-button"]');
-
-    // Wait for revalidation
-    await page.waitForTimeout(500);
-
-    // Reload page - should have new content
-    await page.reload();
-    const revalidatedContent = await page.locator('[data-testid="tagged-content"]').textContent();
-
-    expect(revalidatedContent).not.toBe(firstContent);
+    await waitForChangedContent(page, cachedContent);
   });
 
   test("E2E-202: updateTag immediate expiration", async ({ page }) => {
-    // First visit - get initial timestamp
-    await page.goto("/revalidate-test");
-    const firstContent = await page.locator('[data-testid="tagged-content"]').textContent();
+    await page.goto("/revalidate-test?tag=e2e-202-update");
 
-    // Wait a bit
-    await page.waitForTimeout(200);
+    // Establish a confirmed-cached baseline (stable across reloads).
+    const cachedContent = await waitForCachedContent(page);
 
-    // Click update button
+    // updateTag should expire the entry, so the next load changes.
     await page.click('[data-testid="update-button"]');
-
-    // Wait for update
-    await page.waitForTimeout(500);
-
-    // Reload page - should have new content immediately
-    await page.reload();
-    const updatedContent = await page.locator('[data-testid="tagged-content"]').textContent();
-
-    expect(updatedContent).not.toBe(firstContent);
+    await waitForChangedContent(page, cachedContent);
   });
 });


### PR DESCRIPTION
## Description

`E2E-201` (revalidateTag) was intermittently failing. Root cause analysis:

- It asserted the cached component stayed identical across a single 200ms-delayed reload. The `"use cache"` write commits **asynchronously** with no client-observable signal, so when the first render was a cold miss whose write hadn't landed, the reload was another miss → different timestamp/`Math.random()` → assertion failed.
- The two tests also shared a hardcoded `test-tag`, so `E2E-201`'s `revalidateTag(tag, "max")` (which sets a far-future expiry) poisoned the shared tag and prevented re-caching for the other test.

## Changes

- **Condition-based waiting** instead of fixed timeouts: poll (settle → reload → compare) until two consecutive loads match to confirm caching, then poll until content changes to confirm invalidation.
- **Per-test tag isolation** via `?tag=` on `/revalidate-test`, so invalidating one test's tag can't affect another. `searchParams` access is wrapped in `<Suspense>` per cacheComponents rules.

## Testing

- `revalidation.spec.ts` passes across repeated independent runs (fresh Redis each), redis cache handler.
- Build, lint, typecheck green.

## Type of Change

- [x] Bug fix (flaky test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)