### PR TITLE
test: serialization + large-payload coverage; document tag re-cache bug

### DIFF
--- a/apps/e2e-test-app/app/payload-test/page.tsx
+++ b/apps/e2e-test-app/app/payload-test/page.tsx
@@ -1,0 +1,24 @@
+import { getLargePayload } from "@/lib/large-payload";
+
+// E2E-301: Large / nested / unicode payload serialization through the cache.
+
+export default async function Page() {
+  const data = await getLargePayload();
+
+  return (
+    <div>
+      <h1>E2E-301: Large Payload Serialization</h1>
+      <div data-testid="payload-summary">
+        <p data-testid="payload-stamp">Stamp: {data.generatedAt}</p>
+        <p data-testid="payload-count">Count: {data.count}</p>
+        <p data-testid="payload-unicode">Unicode: {data.unicode}</p>
+        <p data-testid="payload-first">First: {data.first.label}</p>
+        <p data-testid="payload-last">Last: {data.last.label}</p>
+        <p data-testid="payload-nested">
+          Nested: {data.last.nested.value}/{data.last.nested.tags.join(",")}
+        </p>
+      </div>
+      <a href="/">Back to home</a>
+    </div>
+  );
+}

--- a/apps/e2e-test-app/lib/large-payload.ts
+++ b/apps/e2e-test-app/lib/large-payload.ts
@@ -1,0 +1,33 @@
+import { cacheLife, cacheTag } from "next/cache";
+
+export const PAYLOAD_ITEM_COUNT = 500;
+export const PAYLOAD_UNICODE = "Ünïcödé ✓ 中文 日本語 🎉🚀 — quotes \" ' and \\ backslash";
+
+/**
+ * A deliberately large, deeply-nested, unicode-rich payload used to exercise
+ * serialization of realistic RSC-sized data through the cache handler. If the
+ * payload survives a cache round-trip intact (and stays stable across reloads),
+ * the handler is serializing complex data correctly.
+ */
+export async function getLargePayload() {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("large-payload");
+
+  const items = Array.from({ length: PAYLOAD_ITEM_COUNT }, (_, i) => ({
+    id: i,
+    label: `Item ${i} — ${PAYLOAD_UNICODE}`,
+    nested: { value: i * 2, tags: [`tag-${i}`, `tag-${i + 1}`], flag: i % 2 === 0 },
+  }));
+
+  return {
+    // A per-cache-write stamp so "stable across reloads" proves a cache hit.
+    generatedAt: new Date().toISOString(),
+    random: Math.random(),
+    unicode: PAYLOAD_UNICODE,
+    count: items.length,
+    first: items[0],
+    last: items[items.length - 1],
+    items,
+  };
+}

--- a/apps/e2e-test-app/tests/e2e/payload-serialization.spec.ts
+++ b/apps/e2e-test-app/tests/e2e/payload-serialization.spec.ts
@@ -1,0 +1,63 @@
+import { type Page, expect, test } from "@playwright/test";
+import { PAYLOAD_ITEM_COUNT, PAYLOAD_UNICODE } from "../../lib/large-payload";
+
+const SUMMARY = '[data-testid="payload-summary"]';
+
+/**
+ * Polls (settle + reload + compare) until two consecutive loads match, proving
+ * the payload is served from cache rather than re-generated. Mirrors the
+ * condition-based pattern used by the revalidation specs.
+ */
+async function waitForCachedSummary(page: Page): Promise<string> {
+  let cached = "";
+  await expect(async () => {
+    const before = await page.locator(SUMMARY).textContent();
+    await page.waitForTimeout(500);
+    await page.reload();
+    const after = await page.locator(SUMMARY).textContent();
+    expect(after).toBe(before);
+    cached = after ?? "";
+  }).toPass({ timeout: 20_000, intervals: [500, 1000] });
+  return cached;
+}
+
+test.describe("Large Payload Serialization (E2E-301)", () => {
+  test("E2E-301: large, nested, unicode payload round-trips through the cache intact", async ({
+    page,
+  }) => {
+    await page.goto("/payload-test");
+
+    // The content must stabilize across reloads (served from cache).
+    await waitForCachedSummary(page);
+
+    // All fields survive the cache serialization round-trip.
+    await expect(page.locator('[data-testid="payload-count"]')).toHaveText(
+      `Count: ${PAYLOAD_ITEM_COUNT}`,
+    );
+    await expect(page.locator('[data-testid="payload-unicode"]')).toHaveText(
+      `Unicode: ${PAYLOAD_UNICODE}`,
+    );
+    await expect(page.locator('[data-testid="payload-first"]')).toHaveText(
+      `First: Item 0 — ${PAYLOAD_UNICODE}`,
+    );
+    await expect(page.locator('[data-testid="payload-last"]')).toHaveText(
+      `Last: Item ${PAYLOAD_ITEM_COUNT - 1} — ${PAYLOAD_UNICODE}`,
+    );
+    // Deeply-nested values are preserved.
+    await expect(page.locator('[data-testid="payload-nested"]')).toHaveText(
+      `Nested: ${(PAYLOAD_ITEM_COUNT - 1) * 2}/tag-${PAYLOAD_ITEM_COUNT - 1},tag-${PAYLOAD_ITEM_COUNT}`,
+    );
+  });
+
+  test("E2E-301b: cached payload stays byte-identical across reloads", async ({ page }) => {
+    await page.goto("/payload-test");
+
+    const cached = await waitForCachedSummary(page);
+
+    // Two more reloads must return exactly the same content (stable cache hit).
+    await page.reload();
+    expect(await page.locator(SUMMARY).textContent()).toBe(cached);
+    await page.reload();
+    expect(await page.locator(SUMMARY).textContent()).toBe(cached);
+  });
+});

--- a/implementation/ISSUES.md
+++ b/implementation/ISSUES.md
@@ -1,0 +1,70 @@
+# Known Issues
+
+## ISSUE-1: `revalidateTag(tag, "max")` permanently blocks re-caching for that tag
+
+**Status:** Open · **Severity:** High · **Area:** `data-cache/redis.ts` (tag invalidation)
+
+### Summary
+
+After `revalidateTag(tag, "max")` (or any `revalidateTag(tag, <duration>)` with a
+future expire), content for that tag can no longer be cached — every subsequent
+`get()` for an entry carrying that tag returns `undefined`, so the page
+re-renders fresh on every request until the (potentially far-future) expiry
+passes.
+
+Because Next.js now deprecates the single-argument form and instructs callers to
+pass `"max"` (`"revalidateTag" without the second argument is now deprecated, add
+second argument of "max" or use "updateTag"`), this affects normal usage.
+
+### Reproduction (handler level, deterministic)
+
+```js
+const handler = createRedisDataCacheHandler({ redis: createIoredisAdapter(ioredis), defaultTTL: 86400 });
+
+// 1. cache + serve an entry tagged "T"  -> served ✅
+// 2. handler.updateTags(["T"], { expire: 31536000 })   // what revalidateTag(tag,"max") triggers
+// 3. cache a NEW entry tagged "T", then get() it       -> returns null ❌ (expected: served)
+
+// Control: handler.updateTags(["T"]) (immediate expiry) does NOT block re-caching ✅
+```
+
+Observed at the e2e level too: once `E2E-201` revalidated the shared `test-tag`
+with `"max"`, the tag could not be re-cached, which is why the revalidation specs
+now use per-test isolated tags.
+
+### Root cause
+
+`updateTags(tags, durations)` stores a **future** deadline:
+
+```ts
+const expired = now + durations.expire * 1000; // far future for "max"
+await redis.hSet(key, "expired", expired.toString());
+```
+
+…but `get()` treats `expired` as the moment of invalidation and deletes any
+entry created before it:
+
+```ts
+if (expired > entry.timestamp) {   // far-future > any fresh entry.timestamp -> always true
+  await redis.del(key);
+  return undefined;
+}
+```
+
+A freshly written entry always has `timestamp < expired`, so it is deleted on the
+next read. The `expired` field conflates two concepts: *when the tag was
+invalidated* (≈ `now`, which `stale` already records) versus *the future
+expiration deadline* (used by `getExpiration`).
+
+### Proposed direction (needs validation against the Next.js DataCacheHandler contract)
+
+- Gate the hard-delete on the **invalidation time**, not the future deadline —
+  e.g. record an `invalidatedAt = now` and delete entries with
+  `entry.timestamp < invalidatedAt`, keeping `expired`/`getExpiration` for the
+  expiration deadline only.
+- Add e2e + handler tests covering: revalidate a tag with `"max"`, then confirm
+  the tag re-caches on the next render.
+
+A skipped test documenting the expected behavior lives in
+`packages/cache-handler/src/data-cache/redis.test.ts`
+(`re-caches a tag after revalidateTag with a future expire`).

--- a/packages/cache-handler/src/data-cache/redis.test.ts
+++ b/packages/cache-handler/src/data-cache/redis.test.ts
@@ -289,4 +289,28 @@ describe("RedisDataCacheHandler", () => {
     expect(redis.setCalls).toHaveLength(1);
     expect(redis.setCalls[0].args).toEqual([{ EX: 3600 }]);
   });
+
+  // Documents ISSUE-1 (implementation/ISSUES.md): once a tag is invalidated with
+  // a future expire — what `revalidateTag(tag, "max")` triggers — `get()` treats
+  // the far-future `expired` deadline as the invalidation moment and deletes any
+  // entry whose timestamp precedes it, so the tag can never be re-cached.
+  // Skipped until the tag-invalidation comparison is fixed.
+  test.skip("re-caches a tag after revalidateTag with a future expire", async () => {
+    const redis = new FakeRedis();
+    const handler = createRedisDataCacheHandler({ redis, defaultTTL: 86400 });
+
+    await handler.set("k1", Promise.resolve(createEntry("v1", { tags: ["T"] })));
+    expect(await handler.get("k1", [])).toBeTruthy();
+
+    // Simulate revalidateTag("T", "max") -> a far-future expire.
+    await handler.updateTags(["T"], { expire: 31_536_000 });
+
+    // A new entry written after the invalidation must be cacheable again.
+    await handler.set("k2", Promise.resolve(createEntry("v2", { tags: ["T"] })));
+    const result = await handler.get("k2", []);
+    if (!result) {
+      throw new Error("expected the re-cached entry to be served");
+    }
+    expect(await readStream(result.value)).toBe("v2");
+  });
 });

--- a/packages/cache-handler/src/helpers/serialization.test.ts
+++ b/packages/cache-handler/src/helpers/serialization.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+import { jsonReplacer, jsonReviver } from "./serialization.js";
+
+/**
+ * Serialize and deserialize a value the same way the cache handlers do, so the
+ * tests exercise the replacer/reviver pair as an end-to-end round trip.
+ */
+function roundTrip<T>(value: T): unknown {
+  return JSON.parse(JSON.stringify(value, jsonReplacer), jsonReviver);
+}
+
+describe("serialization helpers", () => {
+  describe("Map", () => {
+    test("round-trips a Map preserving entries and order", () => {
+      const map = new Map<string, number>([
+        ["a", 1],
+        ["b", 2],
+      ]);
+
+      const result = roundTrip(map);
+
+      expect(result).toBeInstanceOf(Map);
+      expect([...(result as Map<string, number>)]).toEqual([
+        ["a", 1],
+        ["b", 2],
+      ]);
+    });
+
+    test("round-trips an empty Map", () => {
+      const result = roundTrip(new Map());
+      expect(result).toBeInstanceOf(Map);
+      expect((result as Map<unknown, unknown>).size).toBe(0);
+    });
+
+    test("round-trips a Map nested inside an object", () => {
+      const value = { segmentData: new Map([["/page", "data"]]) };
+      const result = roundTrip(value) as { segmentData: Map<string, string> };
+
+      expect(result.segmentData).toBeInstanceOf(Map);
+      expect(result.segmentData.get("/page")).toBe("data");
+    });
+  });
+
+  describe("Buffer", () => {
+    test("round-trips a Buffer preserving bytes", () => {
+      const buf = Buffer.from("hello world", "utf-8");
+      const result = roundTrip(buf);
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect((result as Buffer).toString("utf-8")).toBe("hello world");
+    });
+
+    test("round-trips binary (non-UTF8) bytes", () => {
+      const buf = Buffer.from([0x00, 0xff, 0x10, 0x80, 0x7f]);
+      const result = roundTrip(buf) as Buffer;
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect([...result]).toEqual([0x00, 0xff, 0x10, 0x80, 0x7f]);
+    });
+
+    test("round-trips an empty Buffer", () => {
+      const result = roundTrip(Buffer.alloc(0));
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect((result as Buffer).length).toBe(0);
+    });
+  });
+
+  describe("Next.js APP_PAGE shape (Map<string, Buffer>)", () => {
+    test("round-trips a Map of Buffers (segmentData)", () => {
+      const segmentData = new Map<string, Buffer>([
+        ["/layout", Buffer.from("layout-rsc")],
+        ["/page", Buffer.from("page-rsc")],
+      ]);
+
+      const result = roundTrip(segmentData) as Map<string, Buffer>;
+
+      expect(result).toBeInstanceOf(Map);
+      expect(Buffer.isBuffer(result.get("/layout"))).toBe(true);
+      expect(result.get("/layout")?.toString()).toBe("layout-rsc");
+      expect(result.get("/page")?.toString()).toBe("page-rsc");
+    });
+  });
+
+  describe("backward compatibility", () => {
+    test("revives Node's native Buffer.toJSON() representation", () => {
+      // What `JSON.stringify(buffer)` produces without the custom replacer.
+      const native = { type: "Buffer", data: [104, 105] }; // "hi"
+      const result = JSON.parse(JSON.stringify(native), jsonReviver);
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect((result as Buffer).toString()).toBe("hi");
+    });
+  });
+
+  describe("guards against false positives", () => {
+    test("does not convert user data shaped like a serialized Buffer", () => {
+      // `data` is a string, not base64 marker — must stay a plain object.
+      const userValue = { __serialized_type: "Buffer" };
+      const result = roundTrip(userValue);
+      expect(result).toEqual(userValue);
+    });
+
+    test("does not convert { type: 'Buffer' } with non-numeric data", () => {
+      const userValue = { type: "Buffer", data: ["not", "bytes"] };
+      const result = roundTrip(userValue);
+      expect(Buffer.isBuffer(result)).toBe(false);
+      expect(result).toEqual(userValue);
+    });
+
+    test("does not convert a fake Map marker with malformed entries", () => {
+      const userValue = { __serialized_type: "Map", entries: "not-an-array" };
+      const result = roundTrip(userValue);
+      expect(result).not.toBeInstanceOf(Map);
+      expect(result).toEqual(userValue);
+    });
+  });
+
+  describe("plain values pass through untouched", () => {
+    test("leaves primitives, arrays, and plain objects unchanged", () => {
+      const value = {
+        n: 42,
+        s: "text",
+        b: true,
+        nil: null,
+        arr: [1, "two", false],
+        nested: { x: { y: "z" } },
+      };
+      expect(roundTrip(value)).toEqual(value);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Expands cache-component test coverage and documents a discovered bug.

### Added tests
- **`serialization.test.ts`** — direct unit tests for `jsonReplacer`/`jsonReviver` (the Map/Buffer serialization behind #15): Map and Buffer round-trips, nested `Map<string, Buffer>` (the Next.js APP_PAGE `segmentData` shape), binary + empty buffers, Node `Buffer.toJSON()` backward-compat, and guards against user data shaped like the serialized markers.
- **`payload-serialization.spec.ts` (E2E-301)** — caches a large (500-item), deeply-nested, unicode-rich payload and asserts it round-trips through Redis intact and stays byte-identical across reloads.

### Documented bug (not fixed here)
- **ISSUE-1** (`implementation/ISSUES.md`): `revalidateTag(tag, "max")` sets a far-future tag `expired` value that `get()` compares against `entry.timestamp`, deleting every freshly-cached entry and **permanently blocking re-caching for that tag**. Confirmed at the handler level. Captured by a skipped test in `data-cache/redis.test.ts`. Left for review since the correct fix depends on the Next.js DataCacheHandler `updateTags`/`getExpiration` contract.

## Testing
- Unit: 114 passed, 1 skipped (the documented bug).
- E2E-301 passes across repeated independent runs (redis), lint + typecheck green.

## Type of Change
- [x] Tests / documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)