### PR TITLE
docs: clarify Redis client contract + document createIoredisAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,28 @@ export default createCacheHandler({
 });
 ```
 
+### Advanced: Bring Your Own Redis Client
+
+To share a connection or use Sentinel/Cluster, pass your own client. The data
+cache handler expects a **node-redis-style** client; node-redis works directly,
+and ioredis is wrapped with `createIoredisAdapter`:
+
+```javascript
+// ioredis (wrap with the adapter)
+import Redis from "ioredis";
+import {
+  createRedisDataCacheHandler,
+  createIoredisAdapter,
+} from "@mrjasonroy/cache-components-cache-handler";
+
+const redis = new Redis(process.env.REDIS_URL);
+export default createRedisDataCacheHandler({ redis: createIoredisAdapter(redis) });
+```
+
+The ISR `RedisCacheHandler` likewise accepts an existing ioredis client via its
+`redis` option. See [docs/redis.md](./docs/redis.md) for node-redis, Sentinel,
+and Cluster examples.
+
 ## Usage
 
 ```typescript

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -62,6 +62,31 @@ export default createRedisDataCacheHandler({
 });
 ```
 
+> `redis` must be a **node-redis-style** client. node-redis (`createClient`)
+> works directly; for **ioredis**, wrap it with `createIoredisAdapter` (below).
+
+### `createIoredisAdapter(client)`
+
+Wraps an [ioredis](https://github.com/redis/ioredis) client (or `Cluster`) so it
+satisfies the node-redis-style `RedisClient` contract expected by
+`createRedisDataCacheHandler`. It translates node-redis SET options
+(`{ EX: seconds }`) to ioredis positional args (`"EX", seconds`); without it,
+Redis rejects writes with `ERR syntax error` and TTLs silently fail.
+
+```javascript
+import Redis from "ioredis";
+import {
+  createRedisDataCacheHandler,
+  createIoredisAdapter,
+} from "@mrjasonroy/cache-components-cache-handler";
+
+const redis = new Redis(process.env.REDIS_URL);
+
+export default createRedisDataCacheHandler({
+  redis: createIoredisAdapter(redis),
+});
+```
+
 ## Next.js Cache APIs
 
 These are Next.js built-in APIs that work with this cache handler.

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,19 +1,56 @@
 # Redis Configuration
 
-This package uses `ioredis` for Redis connections. Install it as a peer dependency:
+Install a Redis client as a peer dependency:
 
 ```bash
 npm install ioredis
+# or, if you prefer node-redis:
+npm install redis
 ```
 
+## Which client and how to pass it
+
+`createRedisDataCacheHandler` expects a **node-redis-style** `RedisClient` — its
+`set()` takes options as an object (`set(key, value, { EX: seconds })`).
+
+- **node-redis** (`redis`) speaks this natively — pass the client directly.
+- **ioredis** uses positional args (`set(key, value, "EX", seconds)`), so wrap it
+  with `createIoredisAdapter()`. Passing a raw ioredis client will make Redis
+  reject writes with `ERR syntax error` and silently break TTLs.
+
+The zero-config `createCacheHandler({ type: "redis" })` uses ioredis internally
+and applies this adapter for you.
+
 ## Basic Setup (for "use cache" directive)
+
+Using **ioredis** (wrap with `createIoredisAdapter`):
 
 ```javascript
 // data-cache-handler.mjs
 import Redis from "ioredis";
-import { createRedisDataCacheHandler } from "@mrjasonroy/cache-components-cache-handler";
+import {
+  createRedisDataCacheHandler,
+  createIoredisAdapter,
+} from "@mrjasonroy/cache-components-cache-handler";
 
 const redis = new Redis(process.env.REDIS_URL || "redis://localhost:6379");
+
+export default createRedisDataCacheHandler({
+  redis: createIoredisAdapter(redis),
+  keyPrefix: "myapp:cache:",
+  tagPrefix: "myapp:tags:",
+});
+```
+
+Using **node-redis** (pass the client directly):
+
+```javascript
+// data-cache-handler.mjs
+import { createClient } from "redis";
+import { createRedisDataCacheHandler } from "@mrjasonroy/cache-components-cache-handler";
+
+const redis = createClient({ url: process.env.REDIS_URL || "redis://localhost:6379" });
+await redis.connect();
 
 export default createRedisDataCacheHandler({
   redis,
@@ -95,7 +132,7 @@ redis.on("ready", () => {
 
 ```javascript
 export default createRedisDataCacheHandler({
-  redis,                          // ioredis client instance
+  redis,                          // node-redis client, or createIoredisAdapter(ioredisClient)
   keyPrefix: "myapp:cache:",      // Namespace for cache keys
   tagPrefix: "myapp:tags:",       // Namespace for cache tags
   defaultTTL: 86400,              // Default TTL in seconds (24 hours)
@@ -134,10 +171,14 @@ docker compose up -d
 
 ### Redis Sentinel (High Availability)
 
-For automatic failover:
+For automatic failover, configure ioredis and wrap it with `createIoredisAdapter`:
 
 ```javascript
 import Redis from "ioredis";
+import {
+  createRedisDataCacheHandler,
+  createIoredisAdapter,
+} from "@mrjasonroy/cache-components-cache-handler";
 
 const redis = new Redis({
   sentinels: [
@@ -147,20 +188,28 @@ const redis = new Redis({
   ],
   name: "mymaster",
 });
+
+export default createRedisDataCacheHandler({ redis: createIoredisAdapter(redis) });
 ```
 
 ### Redis Cluster (Horizontal Scaling)
 
-For distributed deployments:
+For distributed deployments (`Cluster` also satisfies `createIoredisAdapter`):
 
 ```javascript
 import { Cluster } from "ioredis";
+import {
+  createRedisDataCacheHandler,
+  createIoredisAdapter,
+} from "@mrjasonroy/cache-components-cache-handler";
 
 const redis = new Cluster([
   { host: "node1", port: 6379 },
   { host: "node2", port: 6379 },
   { host: "node3", port: 6379 },
 ]);
+
+export default createRedisDataCacheHandler({ redis: createIoredisAdapter(redis) });
 ```
 
 ### Key Expiration


### PR DESCRIPTION
## Description

After #28, the data cache handler speaks node-redis dialect. The docs still showed passing a **raw ioredis** client to `createRedisDataCacheHandler`, which now fails with `ERR syntax error` and silently breaks TTLs.

## Changes
- **README**: add a "Bring Your Own Redis Client" section (node-redis direct, ioredis via `createIoredisAdapter`).
- **docs/redis.md**: explain the node-redis vs ioredis dialect; fix the Basic Setup; show node-redis + ioredis setups and Sentinel/Cluster wrapped with the adapter.
- **docs/api-reference.md**: document `createIoredisAdapter` and note the client contract.

Resolves the doc-consistency point raised on #28.

## Type of Change
- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)