### PR TITLE
fix: re-cache tags after revalidateTag with a future expire (ISSUE-1)

### DIFF
--- a/implementation/ISSUES.md
+++ b/implementation/ISSUES.md
@@ -2,7 +2,17 @@
 
 ## ISSUE-1: `revalidateTag(tag, "max")` permanently blocks re-caching for that tag
 
-**Status:** Open · **Severity:** High · **Area:** `data-cache/redis.ts` (tag invalidation)
+**Status:** ✅ Resolved · **Severity:** High · **Area:** `data-cache/redis.ts` (tag invalidation)
+
+**Fix:** `updateTags` now records the revalidation **event time** (`now`) in the
+tag's `stale` field and uses `expired` only as the hard-deletion deadline.
+`get()` treats an entry as affected only when it was created *before* the event
+(`revalidatedAt > entry.timestamp`), so entries cached *after* a revalidation are
+served normally; affected entries are served stale (`revalidate = -1`) until the
+deadline, then deleted. `getExpiration` returns the event time per the Next.js
+contract. Covered by tests in `data-cache/redis.test.ts`
+(`re-caches a tag after revalidateTag with a future expire`,
+`getExpiration returns the latest revalidation event timestamp`).
 
 ### Summary
 

--- a/packages/cache-handler/src/data-cache/redis.test.ts
+++ b/packages/cache-handler/src/data-cache/redis.test.ts
@@ -290,27 +290,52 @@ describe("RedisDataCacheHandler", () => {
     expect(redis.setCalls[0].args).toEqual([{ EX: 3600 }]);
   });
 
-  // Documents ISSUE-1 (implementation/ISSUES.md): once a tag is invalidated with
-  // a future expire — what `revalidateTag(tag, "max")` triggers — `get()` treats
-  // the far-future `expired` deadline as the invalidation moment and deletes any
-  // entry whose timestamp precedes it, so the tag can never be re-cached.
-  // Skipped until the tag-invalidation comparison is fixed.
-  test.skip("re-caches a tag after revalidateTag with a future expire", async () => {
+  // ISSUE-1 (implementation/ISSUES.md): a tag invalidated with a future expire —
+  // what `revalidateTag(tag, "max")` triggers — must still allow re-caching. The
+  // invalidation only affects entries created *before* the revalidation event.
+  test("re-caches a tag after revalidateTag with a future expire (fixes ISSUE-1)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+
     const redis = new FakeRedis();
     const handler = createRedisDataCacheHandler({ redis, defaultTTL: 86400 });
 
-    await handler.set("k1", Promise.resolve(createEntry("v1", { tags: ["T"] })));
-    expect(await handler.get("k1", [])).toBeTruthy();
+    // Entry cached before the revalidation.
+    await handler.set("k1", Promise.resolve(createEntry("v1", { tags: ["T"], revalidate: 600 })));
 
-    // Simulate revalidateTag("T", "max") -> a far-future expire.
+    // Simulate revalidateTag("T", "max") -> a far-future expire window.
+    vi.setSystemTime(new Date(BASE_TIME.getTime() + 1000));
     await handler.updateTags(["T"], { expire: 31_536_000 });
 
-    // A new entry written after the invalidation must be cacheable again.
-    await handler.set("k2", Promise.resolve(createEntry("v2", { tags: ["T"] })));
-    const result = await handler.get("k2", []);
-    if (!result) {
+    // A new entry written AFTER the revalidation must be cacheable and served.
+    vi.setSystemTime(new Date(BASE_TIME.getTime() + 2000));
+    await handler.set("k2", Promise.resolve(createEntry("v2", { tags: ["T"], revalidate: 600 })));
+    const fresh = await handler.get("k2", []);
+    if (!fresh) {
       throw new Error("expected the re-cached entry to be served");
     }
-    expect(await readStream(result.value)).toBe("v2");
+    expect(await readStream(fresh.value)).toBe("v2");
+
+    // The pre-existing entry is served stale (revalidate = -1) within the window,
+    // not hard-deleted.
+    const stale = await handler.get("k1", []);
+    if (!stale) {
+      throw new Error("expected the pre-existing entry to be served stale");
+    }
+    expect(stale.revalidate).toBe(-1);
+  });
+
+  test("getExpiration returns the latest revalidation event timestamp", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+
+    const redis = new FakeRedis();
+    const handler = createRedisDataCacheHandler({ redis });
+
+    expect(await handler.getExpiration(["T"])).toBe(0);
+
+    // The event timestamp is "now", not now + expire.
+    await handler.updateTags(["T"], { expire: 100 });
+    expect(await handler.getExpiration(["T"])).toBe(BASE_TIME.getTime());
   });
 });

--- a/packages/cache-handler/src/data-cache/redis.ts
+++ b/packages/cache-handler/src/data-cache/redis.ts
@@ -218,26 +218,25 @@ export function createRedisDataCacheHandler(
           return undefined;
         }
 
-        // Check tag expiration
+        // Check tag invalidation. A revalidation only affects entries created
+        // *before* the event — `stale` records when the tag was revalidated, so
+        // entries cached afterward stay valid (this is what makes a tag
+        // re-cacheable after `revalidateTag(tag, "max")`). `expired`, when set,
+        // is the hard-deletion deadline; before it, the entry is served stale.
         let revalidate = entry.revalidate;
         for (const tag of entry.tags) {
           const tagData = await redis.hGetAll(getTagKey(tag));
+          const revalidatedAt = tagData.stale ? Number.parseInt(tagData.stale, 10) : 0;
+          const expireAt = tagData.expired ? Number.parseInt(tagData.expired, 10) : 0;
 
-          if (tagData.expired) {
-            const expired = Number.parseInt(tagData.expired, 10);
-            if (expired > entry.timestamp) {
+          if (revalidatedAt && revalidatedAt > entry.timestamp) {
+            if (expireAt && Date.now() >= expireAt) {
               log?.("get", cacheKey, "had expired tag", tag);
               await redis.del(key);
               return undefined;
             }
-          }
-
-          if (tagData.stale) {
-            const stale = Number.parseInt(tagData.stale, 10);
-            if (stale > entry.timestamp) {
-              log?.("get", cacheKey, "had stale tag", tag);
-              revalidate = -1;
-            }
+            log?.("get", cacheKey, "had stale tag", tag);
+            revalidate = -1;
           }
         }
 
@@ -291,9 +290,12 @@ export function createRedisDataCacheHandler(
 
     async getExpiration(tags) {
       try {
+        // Per the Next.js contract, this returns the maximum timestamp of a
+        // revalidate *event* for the tags (when they were last revalidated),
+        // not a future deadline.
         const expirations = await Promise.all(
           tags.map(async (tag) => {
-            const data = await redis.hGet(getTagKey(tag), "expired");
+            const data = await redis.hGet(getTagKey(tag), "stale");
             return data ? Number.parseInt(data, 10) : 0;
           }),
         );
@@ -319,19 +321,20 @@ export function createRedisDataCacheHandler(
           tags.map(async (tag) => {
             const key = getTagKey(tag);
 
-            if (durations) {
-              // Mark as stale immediately
-              await redis.hSet(key, "stale", now.toString());
+            // Always record the revalidation event time. Entries created before
+            // `now` are affected; entries cached afterward remain valid.
+            await redis.hSet(key, "stale", now.toString());
 
-              // Set expiration if provided
-              if (durations.expire !== undefined) {
-                const expired = now + durations.expire * 1000;
-                await redis.hSet(key, "expired", expired.toString());
-              }
-            } else {
-              // Immediate expiration (default behavior)
+            if (!durations) {
+              // No durations -> immediate hard expiration.
               await redis.hSet(key, "expired", now.toString());
+            } else if (durations.expire !== undefined) {
+              // Hard-expire affected entries once the expire window elapses;
+              // until then they are served stale.
+              const expired = now + durations.expire * 1000;
+              await redis.hSet(key, "expired", expired.toString());
             }
+            // `durations` without `expire` -> stale only, no hard deadline.
           }),
         );
       } catch (error) {


### PR DESCRIPTION
## Problem

`revalidateTag(tag, "max")` (which Next.js now recommends over the deprecated single-arg form) calls `updateTags(tags, { expire })`. The handler stored `expired = now + expire*1000` — a far-future deadline — and `get()` deleted any entry whose `timestamp` was before it. Since a freshly-cached entry's timestamp is always before a far-future deadline, **every new entry for that tag was deleted on read**, permanently blocking re-caching until the deadline passed.

Confirmed at the handler level and via the e2e suite (it's why the revalidation specs needed per-test tag isolation).

## Fix (aligned with the Next.js `DataCacheHandler` contract)

- `updateTags` records the revalidation **event time** (`now`) in `stale`; `expired` is only the optional hard-deletion deadline.
- `get()` treats an entry as affected **only if it predates the event** (`revalidatedAt > entry.timestamp`). Affected entries are served stale (`revalidate = -1`) until the deadline, then deleted. Entries cached *after* the revalidation are unaffected → re-caching works.
- `getExpiration` returns the event time (the "maximum timestamp of a revalidate event" per the contract), not a future deadline.

## Testing

- New unit tests: `re-caches a tag after revalidateTag with a future expire`, `getExpiration returns the latest revalidation event timestamp`.
- Existing stale (test) + immediate-expire (test) behaviors unchanged. Full unit suite: 116 passed.
- Real-Redis repro now re-caches after `revalidateTag(tag, "max")`.
- Revalidation-related e2e (revalidation, cache-timing, mixed, revalidate-path): 11 passed.

Closes ISSUE-1 (`implementation/ISSUES.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)