### PR TITLE
ci: auto-trigger publish on version merge + thank contributors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,15 @@ on:
       - "v*.*.*-alpha.*"
       - "v*.*.*-beta.*"
       - "v*.*.*-rc.*"
+  # Allow publishing a tag explicitly. Tags pushed by the default GITHUB_TOKEN
+  # (e.g. from tag-on-version-merge.yml) do not trigger the `push` event above,
+  # so that workflow dispatches this one instead.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. v16.2.9)"
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -18,14 +27,21 @@ jobs:
       contents: write # Required for creating releases
       id-token: write # Required for npm provenance and trusted publishing
 
+    env:
+      # The tag being published, from the push ref or the manual dispatch input.
+      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # For workflow_dispatch, check out the tag (not the default branch).
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Verify git tag matches package version
         run: |
-          # Extract version from git tag (v16.0.0-alpha.0 -> 16.0.0-alpha.0)
-          GIT_TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          # Extract version from the tag (v16.0.0-alpha.0 -> 16.0.0-alpha.0)
+          GIT_TAG_VERSION="${TAG#v}"
 
           # Get version from package.json
           PACKAGE_VERSION=$(node -p "require('./packages/cache-handler/package.json').version")
@@ -96,11 +112,9 @@ jobs:
           npm view @mrjasonroy/cache-components-cache-handler@$PACKAGE_VERSION
 
       - name: Create GitHub Release
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
           DIST_TAG="${{ steps.dist_tag.outputs.tag }}"
 
@@ -123,7 +137,9 @@ jobs:
             -f tag_name="$TAG" \
             --jq '.body')
 
-          # Create release notes with installation instructions + auto-generated notes
+          # Create release notes with installation instructions + auto-generated notes.
+          # The generated notes include a "New Contributors" section that @-mentions
+          # first-time contributors; the thank-you below makes the acknowledgement explicit.
           RELEASE_NOTES=$(cat <<EOF
           ## Installation
 
@@ -136,14 +152,22 @@ jobs:
           ---
 
           $GENERATED_NOTES
+
+          ---
+
+          💜 Thank you to everyone who contributed to this release!
           EOF
           )
 
-          # Create release
-          gh release create "$TAG" \
-            --title "$TITLE" \
-            --notes "$RELEASE_NOTES" \
-            $PRERELEASE_FLAG
-
-          echo "✅ Created GitHub release for $TAG"
+          # Create the release (idempotent: update notes if it already exists, e.g. on re-run)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TITLE" --notes "$RELEASE_NOTES"
+            echo "✅ Updated existing GitHub release for $TAG"
+          else
+            gh release create "$TAG" \
+              --title "$TITLE" \
+              --notes "$RELEASE_NOTES" \
+              $PRERELEASE_FLAG
+            echo "✅ Created GitHub release for $TAG"
+          fi
           echo "🔗 https://github.com/${{ github.repository }}/releases/tag/$TAG"

--- a/.github/workflows/tag-on-version-merge.yml
+++ b/.github/workflows/tag-on-version-merge.yml
@@ -52,6 +52,17 @@ jobs:
           git tag v${{ steps.version.outputs.version }}
           git push origin v${{ steps.version.outputs.version }}
 
+      - name: Trigger publish workflow
+        if: steps.tag_check.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # A tag pushed by GITHUB_TOKEN does not trigger publish.yml's `push`
+          # event, so dispatch it explicitly (workflow_dispatch is exempt from the
+          # anti-recursion rule and runs even when invoked with GITHUB_TOKEN).
+          gh workflow run publish.yml -f tag="v${{ steps.version.outputs.version }}"
+          echo "🚀 Dispatched publish workflow for v${{ steps.version.outputs.version }}"
+
       - name: Summary
         run: |
           if [ "${{ steps.tag_check.outputs.exists }}" = "true" ]; then


### PR DESCRIPTION
## Problem

When a `version-bump/` PR merges, `tag-on-version-merge.yml` creates the `vX.Y.Z` tag using the default `GITHUB_TOKEN`. **Tags pushed by `GITHUB_TOKEN` don't trigger other workflows** (GitHub's anti-recursion rule), so `publish.yml` never ran automatically — releases required a manual tag re-push. (This is exactly what blocked the 16.2.9 auto-publish.)

## Fix

- **`publish.yml`**: add a `workflow_dispatch` trigger with a `tag` input. The job resolves the tag from the push ref *or* the input, checks out that tag, and runs the GitHub Release step for both triggers. Release creation is **idempotent** (edits notes if the release already exists — safe for re-runs).
- **`tag-on-version-merge.yml`**: after pushing the tag, dispatch `publish.yml` via `gh workflow run` (`workflow_dispatch` is exempt from the anti-recursion rule, so it runs even when invoked with `GITHUB_TOKEN`).
- **Release notes**: add an explicit "Thank you to everyone who contributed" line. GitHub's generated notes already @-mention first-time contributors (e.g. @Antignote, @SerMedvid, @bholly24).

## Manual (re)publish

```bash
gh workflow run publish.yml -f tag=v16.2.9
```

> Note: this does not change npm auth. The 16.2.9 publish failed because the `NPM_TOKEN` secret could not authenticate (npm `404` on `PUT`); that token must be refreshed before any publish (manual or automatic) will succeed.

## Type of Change
- [x] Chore (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)