### PR TITLE
ci: publish via OIDC trusted publishing (no more npm tokens)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,11 +69,13 @@ jobs:
           node-version: "22"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Upgrade npm for trusted publishing (OIDC)
+        # Trusted publishing requires npm >= 11.5.1; Node 22 ships an older npm.
+        run: npm install -g npm@latest
 
       - name: Build packages
         run: pnpm build
@@ -93,11 +95,12 @@ jobs:
           fi
           echo "Publishing with tag: $(cat $GITHUB_OUTPUT | grep tag= | cut -d= -f2)"
 
-      - name: Publish to npm
+      - name: Publish to npm (OIDC trusted publishing)
         working-directory: packages/cache-handler
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --tag ${{ steps.dist_tag.outputs.tag }}
+        # No token: authentication uses the workflow's OIDC identity, which must
+        # be configured as a trusted publisher for this package on npmjs.com.
+        # Provenance is attested automatically.
+        run: npm publish --access public --tag ${{ steps.dist_tag.outputs.tag }} --provenance
 
       - name: Verify published
         run: |


### PR DESCRIPTION
## Why

The `NPM_TOKEN` secret expires (last set 2025-11-30 → expired, which blocked the 16.2.9 publish). Granular/automation tokens cap at ~90 days, so this recurs forever. **OIDC trusted publishing removes tokens entirely** — the workflow authenticates with a short-lived GitHub OIDC identity minted per run. Nothing to rotate, nothing to leak.

## Changes
- Remove `NODE_AUTH_TOKEN` from Node setup and the publish step.
- Upgrade npm to latest (trusted publishing requires npm ≥ 11.5.1; Node 22 ships older).
- `npm publish --provenance`; `id-token: write` is already granted.

## ⚠️ One-time setup required (you, on npmjs.com)
On the package page → **Settings → Trusted Publisher → GitHub Actions**, add:
- **Organization/User:** `mrjasonroy`
- **Repository:** `cache-components-cache-handler`
- **Workflow filename:** `publish.yml`
- **Environment:** *(leave blank)*

After that, no npm token is ever needed again — for 16.2.9 or future releases.

## Type of Change
- [x] Chore (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)