### PR TITLE
ci: tolerate npm propagation lag in publish verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,10 +109,18 @@ jobs:
           echo "✅ Published @mrjasonroy/cache-components-cache-handler@$PACKAGE_VERSION"
           echo "📦 npm dist-tag: $DIST_TAG"
 
-          # Wait a moment for npm to propagate
-          sleep 5
-
-          npm view @mrjasonroy/cache-components-cache-handler@$PACKAGE_VERSION
+          # Poll until the new version is queryable; registry propagation can lag
+          # well past a few seconds. The publish step already succeeded, so a slow
+          # read must NOT fail the job (that would skip the GitHub Release step).
+          for i in $(seq 1 12); do
+            if npm view "@mrjasonroy/cache-components-cache-handler@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+              echo "✅ Verified on npm (attempt $i)"
+              npm view "@mrjasonroy/cache-components-cache-handler@$PACKAGE_VERSION"
+              break
+            fi
+            echo "… not visible yet, retrying ($i/12)"
+            sleep 10
+          done
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Why

During the 16.2.9 release, `npm publish` succeeded but the **"Verify published"** step ran `npm view` only 5s later and got a `404` (registry propagation lag). That failed the job, which **skipped the "Create GitHub Release" step** — the release had to be created manually.

## Fix
Poll for the published version (up to ~2 min) and treat a slow read as non-fatal — the `npm publish` step is authoritative. This keeps the GitHub Release step running on every successful publish.

## Type of Change
- [x] Chore (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)