### PR TITLE
feat: ambient version agent (AI review + merge of Next.js bumps)

### DIFF
--- a/.github/workflows/ambient-version-agent.yml
+++ b/.github/workflows/ambient-version-agent.yml
@@ -53,8 +53,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check configuration
+        id: cfg
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Skip cleanly (no failed runs) until the agent is configured.
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ANTHROPIC_API_KEY not set — ambient agent is dormant. See docs/ambient-agent.md."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Find target PRs
         id: targets
+        if: steps.cfg.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ambient-version-agent.yml
+++ b/.github/workflows/ambient-version-agent.yml
@@ -1,0 +1,140 @@
+name: Ambient Version Agent
+
+# An AI agent (Claude Code) that reviews the automated Next.js bump PRs created by
+# nextjs-version-check.yml. For each open `nextjs-*` PR it: reads the new Next.js
+# release notes, runs the full e2e suite, writes/adjusts e2e tests for any new
+# cache-component behavior, and then either approves + merges (clean) or comments
+# its findings and leaves the PR for a human (genuine regression / new issue).
+#
+# SETUP REQUIRED (see docs/ambient-agent.md):
+#   - Secret ANTHROPIC_API_KEY (or wire Claude Code OAuth).
+#   - An approval-capable identity: the default GITHUB_TOKEN CANNOT approve PRs,
+#     so either install the Claude GitHub App, or set secret AGENT_GITHUB_TOKEN to
+#     a PAT / fine-grained token with "Pull requests: read & write".
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review (optional; otherwise all open nextjs-* PRs)"
+        required: false
+        type: string
+  schedule:
+    # ~2h after nextjs-version-check (00:00 UTC) so the bump PR exists first.
+    - cron: "0 2 * * *"
+
+# Avoid two agent runs racing on the same PR.
+concurrency:
+  group: ambient-version-agent-${{ github.event.inputs.pr_number || 'all' }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push test commits to the PR branch
+      pull-requests: write # comment / approve / merge
+      id-token: write
+
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find target PRs
+        id: targets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            echo "prs=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            # All open PRs from auto-update branches.
+            PRS=$(gh pr list --state open --json number,headRefName \
+              --jq '[.[] | select(.headRefName | startswith("nextjs-")) | .number] | join(" ")')
+            echo "prs=$PRS" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Target PRs: $(grep prs= "$GITHUB_OUTPUT" | cut -d= -f2-)"
+
+      - name: Setup pnpm
+        if: steps.targets.outputs.prs != ''
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: steps.targets.outputs.prs != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        if: steps.targets.outputs.prs != ''
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        if: steps.targets.outputs.prs != ''
+        run: pnpm --filter e2e-test-app exec playwright install --with-deps chromium
+
+      - name: Run ambient agent
+        if: steps.targets.outputs.prs != ''
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # An approval-capable token. GITHUB_TOKEN cannot approve PRs, so prefer a
+          # PAT in AGENT_GITHUB_TOKEN (or rely on the Claude GitHub App identity).
+          github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          claude_args: >-
+            --model claude-opus-4-8
+            --allowedTools "Bash,Edit,Write,Read,Grep,Glob,WebFetch"
+          prompt: |
+            You are the release-quality agent for @mrjasonroy/cache-components-cache-handler,
+            a Next.js 16+ cache handler. A daily automation opens PRs from branches named
+            `nextjs-<version>` that bump the package + example apps to a new Next.js version.
+
+            Review these open auto-update PR(s): #${{ steps.targets.outputs.prs }}
+
+            For EACH PR, work on its branch and do the following, in order:
+
+            1. Check out the PR branch (`gh pr checkout <number>`).
+            2. Read the diff and identify the new Next.js version being adopted.
+            3. Fetch the Next.js release notes/changelog for that version (WebFetch
+               https://github.com/vercel/next.js/releases and the relevant tag) and note any
+               changes to caching, "use cache", cacheLife/cacheTag, revalidateTag/updateTag,
+               PPR, or the DataCacheHandler contract.
+            4. Run the full local test suite:
+               - `pnpm install && pnpm build`
+               - `pnpm --filter @mrjasonroy/cache-components-cache-handler test` (unit)
+               - e2e against memory AND redis (redis is available at redis://localhost:6379):
+                 `CACHE_HANDLER=redis REDIS_URL=redis://localhost:6379 pnpm --filter e2e-test-app build`
+                 then `... pnpm --filter e2e-test-app test:e2e`. Repeat with the memory handler.
+            5. If the new Next.js version introduces or changes cache-component behavior that
+               our suite does not cover, WRITE or adjust e2e tests (and unit tests where apt)
+               to cover it. Follow the existing test conventions (see tests/e2e/*.spec.ts and
+               the condition-based caching-wait helpers; isolate tags per test). Commit and
+               push the new tests to the PR branch with a clear message.
+            6. Re-run the suite to confirm green.
+
+            DECISION (be rigorous — never approve on red):
+            - If everything passes and coverage is adequate: post a concise summary comment of
+              what changed and what you verified, then APPROVE the PR
+              (`gh pr review <n> --approve`) and merge it (`gh pr merge <n> --squash`).
+            - If there is a genuine failure, regression, or behavior change that needs a human:
+              post a detailed comment explaining exactly what broke (with logs), do NOT approve,
+              and leave the PR open. Add the label "needs-human" if it exists.
+
+            Constraints:
+            - Only touch test files, the bumped version files, and lockfiles. Do not change
+              library source to force tests green — a real regression must be surfaced, not hidden.
+            - Keep commits scoped and conventional. Run `pnpm format` and `pnpm lint` before committing.

--- a/.github/workflows/nextjs-version-check.yml
+++ b/.github/workflows/nextjs-version-check.yml
@@ -240,12 +240,19 @@ jobs:
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
           echo "all_tests_passed=$ALL_TESTS_PASSED" >> $GITHUB_OUTPUT
 
-      - name: Auto-merge PR if all tests passed
-        if: steps.check_version.outputs.needs_update == 'true' && steps.branch_check.outputs.branch_exists != 'true' && steps.test_memory.outcome == 'success' && steps.test_redis.outcome == 'success'
+      - name: Hand off to the ambient agent
+        if: steps.check_version.outputs.needs_update == 'true' && steps.branch_check.outputs.branch_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "All tests passed! Enabling auto-merge..."
-          gh pr merge nextjs-${{ steps.check_version.outputs.latest_version }} --auto --squash || echo "Auto-merge not available, PR created for manual review"
-
-          echo "✅ PR created and ready for merge"
+          # The ambient agent (Claude Code, ambient-version-agent.yml) reviews this PR:
+          # runs the full suite, writes tests for any new cache behavior, then approves +
+          # merges if clean or flags it for a human. We dispatch it explicitly because a
+          # PR opened by GITHUB_TOKEN does not trigger pull_request workflows, and
+          # workflow_dispatch is exempt from that anti-recursion rule.
+          PR_NUMBER=$(gh pr view nextjs-${{ steps.check_version.outputs.latest_version }} --json number --jq .number)
+          if gh workflow run ambient-version-agent.yml -f pr_number="$PR_NUMBER"; then
+            echo "🤖 Dispatched ambient agent for PR #$PR_NUMBER"
+          else
+            echo "⚠️ Could not dispatch the agent; its scheduled run will pick this PR up."
+          fi

--- a/docs/ambient-agent.md
+++ b/docs/ambient-agent.md
@@ -1,0 +1,67 @@
+# Ambient Version Agent
+
+An AI agent (Claude Code) that turns the daily Next.js bump from a *deterministic
+re-run of the existing tests* into an *actual review of the new version* —
+reading release notes, writing fresh e2e tests for new cache-component behavior,
+and deciding whether to ship.
+
+## The autonomous loop
+
+```
+nextjs-version-check.yml (daily cron)
+  └─ detects new Next.js → branch nextjs-<v> → bump → quick e2e → opens PR
+        └─ dispatches ▶ ambient-version-agent.yml
+              └─ Claude Code, per PR:
+                   1. checks out the branch
+                   2. reads the Next.js <v> release notes
+                   3. runs the full suite (unit + e2e: memory & redis)
+                   4. writes/adjusts e2e tests for new behavior, pushes them
+                   5. clean  → comments summary, APPROVES, squash-merges
+                      issue  → comments findings, leaves PR open (no approval)
+                        └─ merge → tag-on-version-merge.yml → publish.yml (OIDC)
+                              └─ npm publish + GitHub release (contributors credited)
+```
+
+Everything downstream of the merge is already automated and tokenless (see
+[publishing](./publishing/AUTOMATED_RELEASE.md)). The agent closes the one gap
+that required a human: **judging and merging** the bump.
+
+## One-time setup
+
+1. **`ANTHROPIC_API_KEY`** repo secret — the agent's model access.
+   `gh secret set ANTHROPIC_API_KEY`
+
+2. **An approval-capable identity.** GitHub forbids the default `GITHUB_TOKEN`
+   from *approving* pull requests, so the agent needs its own identity:
+   - **Recommended:** install the **Claude GitHub App** on this repo — the action
+     then acts as `claude[bot]` and can approve/comment/merge. *or*
+   - Set **`AGENT_GITHUB_TOKEN`** to a PAT / fine-grained token (account other
+     than the PR author) with **Pull requests: read & write** and **Contents:
+     read & write**. The workflow uses it via the `github_token` input.
+
+3. Keep branch protection's **1 required approval** — that's the gate the agent
+   satisfies. Required status checks still apply, so the agent's merge only goes
+   through once CI is also green.
+
+## Triggers
+
+- **Automatic:** `nextjs-version-check.yml` dispatches the agent for each new
+  bump PR.
+- **Scheduled fallback:** runs daily (~02:00 UTC) and processes any open
+  `nextjs-*` PR that wasn't handled.
+- **Manual:** `gh workflow run ambient-version-agent.yml -f pr_number=<N>`.
+
+## Guardrails
+
+- The agent may only edit tests, version files, and lockfiles — it must **not**
+  change library source to force tests green. A real regression is surfaced (PR
+  left open + comment), never hidden.
+- It must not approve on red.
+- Concurrency is limited per-PR so two runs don't fight.
+
+## Status
+
+v0 scaffold. Validate with a manual run against a real bump PR before relying on
+it unattended, and tune the prompt/allowed-tools as you learn what it gets right.
+The action version (`anthropics/claude-code-action@v1`) and model id may need
+pinning to whatever is current.


### PR DESCRIPTION
## What

The intelligence layer for the self-update platform. Today `nextjs-version-check` detects new Next.js versions and opens `nextjs-<v>` bump PRs — but its auto-merge is a no-op (`allow_auto_merge=false` + a required approval no bot can satisfy), so versions piled up unmerged (10 stale branches, package stuck at 16.1.6). This adds an agent that actually reviews and ships them.

## The loop

```
version-check (daily) → bump PR → dispatch ▶ ambient agent (Claude Code)
   → reads Next release notes → runs full unit+e2e (memory & redis)
   → writes e2e tests for new behavior → approves+merges if clean / flags if not
      → merge → tag → publish (OIDC) → npm + GitHub release
```

## Files
- **`ambient-version-agent.yml`** — Claude Code per open `nextjs-*` PR; provisions Node/pnpm/redis/Playwright, runs the agent with scoped tools. Guardrails: edits tests/version/lockfiles only (never masks a regression in source), never approves on red, per-PR concurrency.
- **`nextjs-version-check.yml`** — swap the dead auto-merge for an explicit agent dispatch.
- **`docs/ambient-agent.md`** — design + required setup.

## ⚠️ Setup before it runs (see docs/ambient-agent.md)
- Secret **`ANTHROPIC_API_KEY`**.
- An **approval-capable identity** — install the **Claude GitHub App** *or* set **`AGENT_GITHUB_TOKEN`** to a PAT with PR write. (`GITHUB_TOKEN` can't approve PRs.)

This is a **v0 scaffold** — I couldn't end-to-end test it without the secrets + a live new Next.js version. Validate with a manual `gh workflow run ambient-version-agent.yml -f pr_number=<N>` against a real bump PR, then tune the prompt.

## Type of Change
- [x] Feature (CI/automation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)