### PR TITLE
ci: consolidate on RELEASE_PAT, remove NPM_TOKEN

### DIFF
--- a/.github/workflows/catch-up-release.yml
+++ b/.github/workflows/catch-up-release.yml
@@ -33,6 +33,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Use the release PAT so the catch-up PR triggers CI and its merge fires
+          # tag-on-version-merge (a GITHUB_TOKEN-opened PR runs no CI and a bot-merge
+          # triggers nothing — GitHub's anti-recursion rule).
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -42,9 +47,6 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: pnpm install
@@ -162,7 +164,8 @@ jobs:
       - name: Create PR and enable auto-merge
         if: steps.versions.outputs.needs_update == 'true' && inputs.dry_run != true
         env:
-          GH_TOKEN: ${{ github.token }}
+          # PAT so the PR triggers CI and the merge fires tag-on-version-merge.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
         run: |
           VERSION="${{ steps.versions.outputs.new_pkg_version }}"
           BRANCH_NAME="catch-up-$VERSION"
@@ -197,7 +200,7 @@ jobs:
             --head $BRANCH_NAME
 
           # Enable auto-merge
-          gh pr merge $BRANCH_NAME --auto --squash
+          gh pr merge $BRANCH_NAME --auto --squash --delete-branch
 
           echo "✅ Created PR and enabled auto-merge"
           echo "🔗 PR will be merged automatically once status checks pass"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -107,7 +107,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ steps.version.outputs.new_version }}
           DIST_TAG: ${{ steps.version.outputs.dist_tag }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}


### PR DESCRIPTION
Collapses release automation to **one secret** (`RELEASE_PAT`) and removes a dead/expired one.

- `version-bump.yml`: `PAT_TOKEN` → `RELEASE_PAT`
- `catch-up-release.yml`: same `RELEASE_PAT` treatment (it had the identical `GITHUB_TOKEN` merge bug — bot-opened PR runs no CI, so auto-merge never fired)
- `catch-up-release.yml`: dropped the `NODE_AUTH_TOKEN: NPM_TOKEN` line — this workflow doesn't publish (OIDC handles that downstream), so it was dead config on an expired token

`NPM_TOKEN` and `PAT_TOKEN` secrets deleted as part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)