### PR TITLE
docs: fix branch-protection accuracy; tighten cluster-safety test

### DIFF
--- a/docs/auto-release.md
+++ b/docs/auto-release.md
@@ -54,18 +54,26 @@ CI is green — the tag and publish still fire automatically from your merge.
 
 `main` requires the status checks `lint-and-typecheck`, `unit-tests`, and
 `test-summary`, and does **not** require an approving review — the checks are the
-gate, and no bot can give itself an approval. Required conversation resolution
-stays on (only matters when a human leaves review comments). Auto-merge and
-delete-branch-on-merge are enabled at the repo level.
+gate, and no bot can give itself an approval. **Required conversation resolution
+is off**: an auto-reviewer (e.g. `gemini-code-assist`) leaves review threads on
+every PR, and with conversation resolution required those unresolved threads
+would block auto-merge — wedging the hands-off bump loop on every release. The
+e2e status checks are the real gate. Auto-merge and delete-branch-on-merge are
+enabled at the repo level.
 
-To re-add a human approval gate later:
+To re-add a human approval gate later (the `required_pull_request_reviews`
+sub-fields are included because the GitHub API rejects a partial object):
 
 ```bash
 gh api -X PUT repos/{owner}/{repo}/branches/main/protection --input - <<'JSON'
 { "required_status_checks": { "strict": false,
     "contexts": ["lint-and-typecheck", "unit-tests", "test-summary"] },
   "enforce_admins": false,
-  "required_pull_request_reviews": { "required_approving_review_count": 1 },
-  "restrictions": null, "required_conversation_resolution": true }
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null, "required_conversation_resolution": false }
 JSON
 ```

--- a/packages/cache-handler/src/data-cache/redis.test.ts
+++ b/packages/cache-handler/src/data-cache/redis.test.ts
@@ -424,8 +424,14 @@ describe("RedisDataCacheHandler cluster safety", () => {
     vi.setSystemTime(new Date(BASE_TIME.getTime() + 5000));
     await handler.get("k2", []);
 
-    // Both deletion paths must have run (otherwise the assertion is vacuous)...
-    expect(commands.some((c) => c.method === "del")).toBe(true);
+    // Both deletion paths must have run (otherwise the assertion is vacuous),
+    // and each must delete exactly the one expected key — tag-driven del of k1,
+    // then TTL-driven del of k2.
+    const delCommands = commands.filter((c) => c.method === "del");
+    expect(delCommands).toEqual([
+      { method: "del", keys: ["nextjs:data-cache:k1"] },
+      { method: "del", keys: ["nextjs:data-cache:k2"] },
+    ]);
     // ...and every command issued must target exactly one key.
     const multiKey = commands.filter((c) => c.keys.length !== 1);
     expect(multiKey).toEqual([]);


### PR DESCRIPTION
## What

Two loose-end cleanups after the release-automation work (#46–#49) landed:

1. **`docs/auto-release.md` accuracy** — the branch-protection section claimed
   required conversation resolution stays *on*. It's **off**, and deliberately so:
   the `gemini-code-assist` auto-reviewer leaves review threads on every PR, and
   with conversation resolution required those unresolved threads would block
   auto-merge — wedging the hands-off bump loop on every release. The e2e status
   checks are the real gate. Also fixed the revert snippet to include the
   `required_pull_request_reviews` sub-fields (the GitHub API rejects a partial
   object).

2. **`redis.test.ts` cluster-safety test** — applies gemini's suggestion from
   #49: assert the `del` calls target exactly the expected single keys
   (`nextjs:data-cache:k1` then `k2`) instead of just "some del happened". Makes
   the single-key invariant assertion exact rather than vacuous-resistant only.

## Checks

- `pnpm lint` ✅  ·  `pnpm typecheck` ✅  ·  unit tests ✅ (123 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
