### PR TITLE
Fix RedisCacheHandler SET TTL calculation

### DIFF
--- a/packages/cache-handler/src/handlers/redis.test.ts
+++ b/packages/cache-handler/src/handlers/redis.test.ts
@@ -421,6 +421,10 @@ describe("RedisCacheHandler", () => {
   });
 
   describe("TTL on set", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     test("should store entry with setex when defaultTTL is configured", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2024-01-02T03:04:05.000Z"));

--- a/packages/cache-handler/src/handlers/redis.test.ts
+++ b/packages/cache-handler/src/handlers/redis.test.ts
@@ -102,6 +102,10 @@ class FakeRedis {
   listenerCount(event: string): number {
     return this.listeners.get(event)?.length ?? 0;
   }
+
+  getStored(key: string): { value: string; ttl?: number } | undefined {
+    return this.store.get(key);
+  }
 }
 
 // Mock ioredis to return our FakeRedis
@@ -413,6 +417,33 @@ describe("RedisCacheHandler", () => {
       // The old entry should have been deleted from Redis
       const rawData = await fakeRedis.get("nextjs:cache:old-app-page");
       expect(rawData).toBeNull();
+    });
+  });
+
+  describe("TTL on set", () => {
+    test("should store entry with setex when defaultTTL is configured", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-01-02T03:04:05.000Z"));
+
+      const handler = new RedisCacheHandler({ defaultTTL: 3600 });
+
+      const value: CacheValue = {
+        kind: "FETCH",
+        data: {
+          headers: { "content-type": "application/json" },
+          body: '{"ttl": true}',
+          status: 200,
+          url: "https://example.com",
+        },
+        revalidate: 3600,
+      };
+
+      await handler.set("ttl-key", value);
+
+      const stored = fakeRedis.getStored("nextjs:cache:ttl-key");
+      expect(stored).toBeDefined();
+      expect(stored?.ttl).toBeGreaterThan(0);
+      expect(stored?.ttl).toBeLessThanOrEqual(3600);
     });
   });
 

--- a/packages/cache-handler/src/handlers/redis.ts
+++ b/packages/cache-handler/src/handlers/redis.ts
@@ -1,5 +1,5 @@
 import Redis, { type RedisOptions } from "ioredis";
-import { calculateLifespan, isExpired } from "../helpers/lifespan.js";
+import { calculateLifespan, isExpired, redisTtlSecondsFromLifespan } from "../helpers/lifespan.js";
 import { jsonReplacer, jsonReviver } from "../helpers/serialization.js";
 import type {
   CacheHandler,
@@ -254,9 +254,8 @@ export class RedisCacheHandler implements CacheHandler {
       // Determine TTL for Redis
       let ttl: number | undefined;
       if (lifespan?.expireAt) {
-        // Use expire time as TTL
-        ttl = Math.ceil((lifespan.expireAt - Date.now()) / 1000);
-        if (ttl <= 0) {
+        ttl = redisTtlSecondsFromLifespan(lifespan);
+        if (!ttl || ttl <= 0) {
           this.log("SET", cacheKey, "SKIP (already expired)");
           return;
         }

--- a/packages/cache-handler/src/helpers/lifespan.test.ts
+++ b/packages/cache-handler/src/helpers/lifespan.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { calculateLifespan, isExpired } from "./lifespan.js";
+import { calculateLifespan, isExpired, redisTtlSecondsFromLifespan } from "./lifespan.js";
 
 const MOCK_TIME = new Date("2024-01-02T03:04:05.000Z");
 
@@ -70,5 +70,21 @@ describe("lifespan helpers", () => {
 
     vi.setSystemTime(new Date(MOCK_TIME.getTime() + 2_000));
     expect(isExpired(lifespan)).toBe(true);
+  });
+
+  test("redisTtlSecondsFromLifespan computes positive Redis TTL from lifespan", () => {
+    const lifespan = calculateLifespan(3600, 3600);
+    const ttl = redisTtlSecondsFromLifespan(lifespan);
+
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(3600);
+  });
+
+  test("redisTtlSecondsFromLifespan documents the broken formula always skips writes", () => {
+    const lifespan = calculateLifespan(3600, 3600);
+    expect(lifespan).not.toBeNull();
+
+    const broken = Math.ceil((lifespan.expireAt - Date.now()) / 1000);
+    expect(broken).toBeLessThanOrEqual(0);
   });
 });

--- a/packages/cache-handler/src/helpers/lifespan.ts
+++ b/packages/cache-handler/src/helpers/lifespan.ts
@@ -51,3 +51,14 @@ export function isExpired(lifespan: LifespanParameters | null): boolean {
   const nowSeconds = Math.floor(Date.now() / 1000);
   return nowSeconds >= lifespan.expireAt;
 }
+
+/**
+ * Compute remaining Redis EX TTL in seconds from lifespan parameters.
+ * expireAt is epoch seconds (see calculateLifespan).
+ */
+export function redisTtlSecondsFromLifespan(
+  lifespan: LifespanParameters | null,
+): number | undefined {
+  if (!lifespan?.expireAt) return undefined;
+  return lifespan.expireAt - Math.floor(Date.now() / 1000);
+}


### PR DESCRIPTION
## Summary
Fixes a Redis cache write bug in `RedisCacheHandler.set()`.
`calculateLifespan()` stores `expireAt` as epoch seconds, but the Redis TTL calculation compared it directly with `Date.now()` in milliseconds. That made the computed TTL `<= 0`, so writes with a TTL were skipped as already expired instead of being stored in Redis.
This changes the Redis TTL calculation to compare seconds with seconds, so `SETEX` receives a positive TTL again.