### PR TITLE
fix nested buffer containing array of numbers instead of base64

### DIFF
--- a/packages/cache-handler/src/helpers/serialization.test.ts
+++ b/packages/cache-handler/src/helpers/serialization.test.ts
@@ -65,6 +65,32 @@ describe("serialization helpers", () => {
     });
   });
 
+  describe("nested Buffer (Node toJSON before replacer)", () => {
+    test("serializes rscData as base64, not int-array JSON", () => {
+      const entry = { rscData: Buffer.from('1:"test"') };
+      const serialized = JSON.stringify(entry, jsonReplacer);
+
+      expect(serialized).toContain('"__serialized_type":"Buffer"');
+      expect(serialized).toContain('"data":"MToidGVzdCI="');
+      expect(serialized).not.toContain('"type":"Buffer"');
+      expect(serialized).not.toMatch(/"data":\[\d+,/);
+    });
+
+    test("round-trips rscData nested in an APP_PAGE-like object", () => {
+      const entry = {
+        kind: "APP_PAGE",
+        rscData: Buffer.from("page-rsc-payload"),
+        html: "<html></html>",
+      };
+      const result = roundTrip(entry) as typeof entry;
+
+      expect(Buffer.isBuffer(result.rscData)).toBe(true);
+      expect(result.rscData.toString()).toBe("page-rsc-payload");
+      expect(result.kind).toBe("APP_PAGE");
+      expect(result.html).toBe("<html></html>");
+    });
+  });
+
   describe("Next.js APP_PAGE shape (Map<string, Buffer>)", () => {
     test("round-trips a Map of Buffers (segmentData)", () => {
       const segmentData = new Map<string, Buffer>([
@@ -102,6 +128,13 @@ describe("serialization helpers", () => {
 
     test("does not convert { type: 'Buffer' } with non-numeric data", () => {
       const userValue = { type: "Buffer", data: ["not", "bytes"] };
+      const result = roundTrip(userValue);
+      expect(Buffer.isBuffer(result)).toBe(false);
+      expect(result).toEqual(userValue);
+    });
+
+    test("does not convert { type: 'Buffer' } with invalid byte values", () => {
+      const userValue = { type: "Buffer", data: [1, 256, 3.5] };
       const result = roundTrip(userValue);
       expect(Buffer.isBuffer(result)).toBe(false);
       expect(result).toEqual(userValue);

--- a/packages/cache-handler/src/helpers/serialization.ts
+++ b/packages/cache-handler/src/helpers/serialization.ts
@@ -6,6 +6,22 @@
  * loses Buffer identity, so custom replacer/reviver functions are needed.
  */
 
+type NodeBufferJson = {
+  type: "Buffer";
+  data: number[];
+};
+
+function isByte(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 255;
+}
+
+function isNodeBufferJson(value: unknown): value is NodeBufferJson {
+  if (!value || typeof value !== "object") return false;
+
+  const obj = value as Record<string, unknown>;
+  return obj.type === "Buffer" && Array.isArray(obj.data) && obj.data.every(isByte);
+}
+
 /**
  * Custom JSON replacer that serializes Map and Buffer instances.
  * - Maps become `{ __serialized_type: "Map", entries: [...] }`
@@ -22,6 +38,14 @@ export function jsonReplacer(_key: string, value: unknown): unknown {
     return {
       __serialized_type: "Buffer",
       data: value.toString("base64"),
+    };
+  }
+  // Node calls Buffer.toJSON() before the replacer — nested Buffers arrive as
+  // `{ type: "Buffer", data: number[] }` instead of a Buffer instance.
+  if (isNodeBufferJson(value)) {
+    return {
+      __serialized_type: "Buffer",
+      data: Buffer.from(value.data).toString("base64"),
     };
   }
   return value;
@@ -51,12 +75,8 @@ export function jsonReviver(_key: string, value: unknown): unknown {
     // Backward compat: Node's Buffer.toJSON() format.
     // Guard with number[] check to avoid false-positives on user data
     // that happens to have { type: "Buffer", data: [...] } shape.
-    if (
-      obj.type === "Buffer" &&
-      Array.isArray(obj.data) &&
-      obj.data.every((n) => typeof n === "number")
-    ) {
-      return Buffer.from(obj.data as number[]);
+    if (isNodeBufferJson(obj)) {
+      return Buffer.from(obj.data);
     }
   }
   return value;


### PR DESCRIPTION
## Description

Fixes oversized serialized `APP_PAGE` cache entries by normalizing nested Node Buffer JSON into the existing base64 serialization format.
The original issue was observed in real Next.js `kind = "APP_PAGE"` cache entries: `rscData` was being stored as a very large `{ type: "Buffer", data: number[] }` object. That number was making entries about 60% larger than expected and needed. Example of the stored shape:

```json
"</body></html>\",\"rscData\":{\"type\":\"Buffer\",\"data\":[49,58,34,36,......]"
```

Next.js APP_PAGE cache entries can include rscData as a Buffer. During JSON.stringify(), Node converts nested Buffers to { type: "Buffer", data: number[] } before the replacer sees them, causing those large byte arrays to be stored. This PR detects that shape and serializes it as { __serialized_type: "Buffer", data: "<base64>" } instead, while preserving correct Buffer round-tripping on read.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chore (dependencies, CI, etc.)

## Testing

- [x] All existing tests pass (`pnpm test`)
- [x] Added new tests for new functionality
- [ ] Tested with memory cache handler
- [x] Tested with Redis cache handler (if applicable)
- [x] E2E tests pass (`pnpm test:e2e`)

Ran:

- `pnpm --filter @mrjasonroy/cache-components-cache-handler test -- src/helpers/serialization.test.ts`
- `pnpm --filter @mrjasonroy/cache-components-cache-handler typecheck`

## Checklist

- [x] My code follows the project's code style (`pnpm lint` passes)
- [x] I have run `pnpm format` to format my code
- [x] Type checking passes (`pnpm typecheck`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues

Fixes oversized `APP_PAGE.rscData` serialization caused by Node’s native `Buffer.toJSON()` output.

## Additional Context

This keeps the fix in the shared serialization boundary used by the Redis cache handler, so Next.js cache values continue to round-trip with the expected `Buffer` and `Map<string, Buffer>` shapes.